### PR TITLE
Feature/storing-groceries

### DIFF
--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/ros/launch/pickup_action.launch
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/ros/launch/pickup_action.launch
@@ -4,5 +4,7 @@
         <param name="arm_name" value="arm" />
         <param name="gripper_cmd_topic" value="gripper_controller" />
         <rosparam param="gripper_joint_names">[gripper]</rosparam>
+        <param name="pregrasp_config_name" value="pregrasp" />
+        <param name="intermediate_grasp_offset" value="0.1" />
     </node>
 </launch>

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/ros/launch/pickup_client.launch
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/ros/launch/pickup_client.launch
@@ -14,5 +14,6 @@
         <remap from="action_feedback_topic" to="$(arg action_feedback_topic)" />
         <remap from="knowledge_update_service" to="$(arg knowledge_update_service)" />
         <remap from="attribute_fetching_service" to="$(arg attribute_fetching_service)" />
+        <rosparam param="closed_gripper_joint_values">[1]</rosparam>
     </node>
 </launch>

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/ros/launch/pickup_client.launch
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/ros/launch/pickup_client.launch
@@ -14,6 +14,6 @@
         <remap from="action_feedback_topic" to="$(arg action_feedback_topic)" />
         <remap from="knowledge_update_service" to="$(arg knowledge_update_service)" />
         <remap from="attribute_fetching_service" to="$(arg attribute_fetching_service)" />
-        <rosparam param="closed_gripper_joint_values">[1]</rosparam>
+        <rosparam param="closed_gripper_joint_values">[0]</rosparam>
     </node>
 </launch>

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/ros/scripts/pickup_action
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/ros/scripts/pickup_action
@@ -21,6 +21,8 @@ class PickupSkill(smach.StateMachine):
         arm_name = rospy.get_param('~arm_name', '')
         gripper_cmd_topic = rospy.get_param('~gripper_cmd_topic', '')
         gripper_joint_names = rospy.get_param('~gripper_joint_names', list())
+        pregrasp_config_name = rospy.get_param('~pregrasp_config_name', 'pregrasp')
+        grasp_offset = float(rospy.get_param('~intermediate_grasp_offset', 0.1))
 
         with self:
             smach.StateMachine.add('SETUP_PICKUP', SetupPickup(),
@@ -29,7 +31,9 @@ class PickupSkill(smach.StateMachine):
 
             smach.StateMachine.add('PICKUP', Pickup(arm_name=arm_name,
                                                     gripper_joint_names=gripper_joint_names,
-                                                    gripper_cmd_topic=gripper_cmd_topic),
+                                                    gripper_cmd_topic=gripper_cmd_topic,
+                                                    pregrasp_config_name=pregrasp_config_name,
+                                                    intermediate_grasp_offset=grasp_offset),
                                    transitions={'succeeded': 'SET_ACTION_LIB_SUCCESS',
                                                 'failed': 'SET_ACTION_LIB_FAILED'})
 

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/ros/scripts/pickup_client
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/ros/scripts/pickup_client
@@ -78,9 +78,10 @@ class PickupClient(ActionClientBase):
 
     def get_object_pose(self, object_name):
         try:
-            obj = self.msg_store_client.query_named(object_name, Object._type)
+            obj = self.msg_store_client.query_named(object_name, Object._type)[0]
             return obj.pose
         except:
+            rospy.logerr('Error retriving knowledge about %s', object_name)
             return PoseStamped()
 
     def update_knowledge_base(self):

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/ros/scripts/pickup_client
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/ros/scripts/pickup_client
@@ -3,14 +3,14 @@ import rospy
 import actionlib
 import tf
 
-from mdr_rosplan_interface.action_client_base import ActionClientBase
-from mdr_pickup_action.msg import PickupAction, PickupGoal
-
+from geometry_msgs.msg import PoseStamped
 import rosplan_dispatch_msgs.msg as plan_dispatch_msgs
 import rosplan_knowledge_msgs.srv as rosplan_srvs
 import diagnostic_msgs.msg as diag_msgs
 
 from mcr_perception_msgs.msg import Object
+from mdr_rosplan_interface.action_client_base import ActionClientBase
+from mdr_pickup_action.msg import PickupAction, PickupGoal
 
 class PickupClient(ActionClientBase):
     def __init__(self):
@@ -19,6 +19,8 @@ class PickupClient(ActionClientBase):
         self.obj_plane = None
         self.obj = None
         self.frame_id = rospy.get_param('~grasping_pose_frame', 'base_link')
+        self.closed_gripper_joint_values = rospy.get_param('~closed_gripper_joint_values',
+                                                           list())
         self.tf_listener = tf.TransformListener()
 
         while not rospy.is_shutdown():
@@ -62,20 +64,27 @@ class PickupClient(ActionClientBase):
                 self.robot_name = param.value
 
         object_pose = self.get_object_pose(self.obj)
+        object_pose.header.stamp = rospy.Time(0)
 
         goal.pose.header.frame_id = self.frame_id
         goal.pose.header.stamp = rospy.Time.now()
-        object_pose_picking_frame = self.tf_listener.transformPose(self.frame_id,
-                                                                   object_pose)
-        goal.pose.pose = object_pose_picking_frame
+        object_pose_in_grasp_frame = self.tf_listener.transformPose(self.frame_id,
+                                                                    object_pose)
+        goal.pose = object_pose_in_grasp_frame
+
+        # a grasp planner should determine this on the fly
+        goal.closed_gripper_joint_values = self.closed_gripper_joint_values
         return goal
 
     def get_object_pose(self, object_name):
-        obj = self.msg_store_client.query_named(object_name, Object._type)
-        return obj.pose
+        try:
+            obj = self.msg_store_client.query_named(object_name, Object._type)
+            return obj.pose
+        except:
+            return PoseStamped()
 
     def update_knowledge_base(self):
-        # we add the fact that the robot is not on the surface anymore to the knowledge base
+        # we remove the fact that the object is on the surface from the knowledge base
         request = rosplan_srvs.KnowledgeUpdateServiceRequest()
         request.update_type = 2
         request.knowledge.knowledge_type = 1
@@ -93,10 +102,10 @@ class PickupClient(ActionClientBase):
 
         self.knowledge_update_client(request)
 
-        # we add the fact that the robot's gripper is not empty anymore to the knowledge base
+        # we remove the fact that the robot's gripper is empty from the knowledge base
         request = rosplan_srvs.KnowledgeUpdateServiceRequest()
-        request.update_type = 0
-        request.knowledge.knowledge_type = 2
+        request.update_type = 2
+        request.knowledge.knowledge_type = 1
         request.knowledge.attribute_name = 'empty_gripper'
 
         arg_msg = diag_msgs.KeyValue()

--- a/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/CMakeLists.txt
+++ b/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   roslint
   rospy
+  geometry_msgs
 )
 
 catkin_python_setup()
@@ -20,6 +21,7 @@ add_action_files(DIRECTORY ros/action
 generate_messages(
   DEPENDENCIES
   actionlib_msgs
+  geometry_msgs
 )
 
 catkin_package(

--- a/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/package.xml
+++ b/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/package.xml
@@ -17,12 +17,14 @@
   <build_depend>message_generation</build_depend>
   <build_depend>roslint</build_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>geometry_msgs</build_depend>
 
   <run_depend>rospy</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
   <run_depend>mcr_states</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>geometry_msgs</run_depend>
 
   <export></export>
 </package>

--- a/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/action/MoveBase.action
+++ b/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/action/MoveBase.action
@@ -1,5 +1,10 @@
+int32 NAMED_TARGET=0
+int32 POSE=1
+
 # goal definition
+int32 goal_type
 string destination_location
+geometry_msgs/PoseStamped pose
 ---
 # result definition
 bool success

--- a/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/launch/move_base_action.launch
+++ b/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/launch/move_base_action.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
     <arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)" />
-    <node pkg="mdr_move_base_action" type="move_base_action" name="move_base_server" output="screen" ns="/mdr_actions">
+    <node pkg="mdr_move_base_action" type="move_base_action" name="move_base_server" output="screen">
         <param name="move_base_server" value="/move_base" />
         <param name="pose_description_file" value="$(find mcr_default_env_config)/$(arg robot_env)/navigation_goals.yaml" />
         <param name="pose_frame" value="map" />

--- a/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/launch/move_base_action.launch
+++ b/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/launch/move_base_action.launch
@@ -5,5 +5,7 @@
         <param name="move_base_server" value="/move_base" />
         <param name="pose_description_file" value="$(find mcr_default_env_config)/$(arg robot_env)/navigation_goals.yaml" />
         <param name="pose_frame" value="map" />
+        <param name="arm_name" value="arm" />
+        <param name="safe_arm_joint_config" value="folded" />
     </node>
 </launch>

--- a/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/launch/move_base_client.launch
+++ b/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/launch/move_base_client.launch
@@ -5,9 +5,9 @@
     <arg name="knowledge_update_service" default="/kcl_rosplan/update_knowledge_base"/>
     <arg name="attribute_fetching_service" default="/kcl_rosplan/get_current_knowledge"/>
 
-    <node pkg="mdr_move_base_action" type="move_base_client" name="mdr_move_base_client" output="screen" ns="mdr_actions">
+    <node pkg="mdr_move_base_action" type="move_base_client" name="mdr_move_base_client" output="screen">
         <param name="action_name" type="str" value="move_base" />
-        <param name="server_name" type="str" value="/mdr_actions/move_base_server" />
+        <param name="server_name" type="str" value="move_base_server" />
         <param name="action_timeout" type="double" value="120" />
         <remap from="action_dispatch_topic" to="$(arg action_dispatch_topic)" />
         <remap from="action_feedback_topic" to="$(arg action_feedback_topic)" />

--- a/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/scripts/move_base_action
+++ b/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/scripts/move_base_action
@@ -12,13 +12,17 @@ def main():
     move_base_server = rospy.get_param('~move_base_server', '')
     pose_description_file = rospy.get_param('~pose_description_file', '')
     pose_frame = rospy.get_param('~pose_frame', '')
+    arm_name = rospy.get_param('~arm_name', 'arm')
+    safe_arm_joint_config = rospy.get_param('~safe_arm_joint_config', 'folded')
 
     sm = smach.StateMachine(outcomes=['OVERALL_SUCCESS', 'OVERALL_FAILED'],
                             input_keys=['move_base_goal'],
                             output_keys=['move_base_feedback', 'move_base_result'])
 
     with sm:
-        smach.StateMachine.add('SETUP_MOVE_BASE', SetupMoveBase(),
+        smach.StateMachine.add('SETUP_MOVE_BASE',
+                               SetupMoveBase(safe_arm_joint_config=safe_arm_joint_config,
+                                             arm_name=arm_name),
                                transitions={'succeeded': 'MOVE_BASE_TO_DESTINATION',
                                             'failed': 'SETUP_MOVE_BASE'})
 

--- a/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/scripts/move_base_action_client_test
+++ b/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/scripts/move_base_action_client_test
@@ -13,6 +13,7 @@ if __name__ == '__main__':
     goal = MoveBaseGoal()
     if len(sys.argv) == 2:
         try:
+            goal.goal_type = MoveBaseGoal.NAMED_TARGET
             goal.destination_location = str(sys.argv[1])
             timeout = 15.0
             rospy.loginfo('Sending action lib goal to move_base_server, ' +

--- a/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/scripts/move_base_client
+++ b/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/scripts/move_base_client
@@ -2,10 +2,11 @@
 import rospy
 import actionlib
 
-from mdr_rosplan_interface.action_client_base import ActionClientBase
-from mdr_move_base_action.msg import MoveBaseAction, MoveBaseGoal
 import rosplan_knowledge_msgs.srv as rosplan_srvs
 import diagnostic_msgs.msg as diag_msgs
+
+from mdr_rosplan_interface.action_client_base import ActionClientBase
+from mdr_move_base_action.msg import MoveBaseAction, MoveBaseGoal
 
 class MoveBaseClient(ActionClientBase):
     def __init__(self):
@@ -51,6 +52,7 @@ class MoveBaseClient(ActionClientBase):
                 goal.destination_location = param.value
             elif param.key == 'bot':
                 self.robot_name = param.value
+        goal.goal_type = MoveBaseGoal.NAMED_TARGET
         return goal
 
     def update_knowledge_base(self, destination_location):

--- a/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/src/mdr_move_base_action/action_states.py
+++ b/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/src/mdr_move_base_action/action_states.py
@@ -25,7 +25,7 @@ class SetupMoveBase(smach.State):
         feedback.message = '[MOVE_BASE] Received a move base request'
         userdata.move_base_feedback = feedback
 
-        rospy.logerr('[MOVE_BASE] Moving arm to safe configuration...')
+        rospy.loginfo('[MOVE_BASE] Moving the arm to a safe configuration...')
         self.arm.clear_pose_targets()
         self.arm.set_named_target(self.safe_arm_joint_config)
         self.arm.go(wait=True)

--- a/mdr_planning/mdr_scenarios/mdr_robocup_tasks/mdr_store_groceries/ros/src/mdr_store_groceries/scenario_states/pick.py
+++ b/mdr_planning/mdr_scenarios/mdr_robocup_tasks/mdr_store_groceries/ros/src/mdr_store_groceries/scenario_states/pick.py
@@ -27,7 +27,7 @@ class Pick(ScenarioStateBase):
         obj_to_grasp_idx = self.select_object_for_grasping(object_poses)
         obj_to_grasp = surface_objects[obj_to_grasp_idx]
 
-        dispatch_msg = self.get_dispatch_msg(grasped_object, 'table')
+        dispatch_msg = self.get_dispatch_msg(obj_to_grasp, 'table')
         rospy.loginfo('Picking %s from the table' % obj_to_grasp)
         self.action_dispatch_pub.publish(dispatch_msg)
 
@@ -71,8 +71,11 @@ class Pick(ScenarioStateBase):
     def get_object_poses(self, surface_objects):
         object_poses = list()
         for obj_name in surface_objects:
-            obj = self.msg_store_client.query_named(obj_name, Object._type)
-            object_poses.append(obj.pose)
+            try:
+                obj = self.msg_store_client.query_named(obj_name, Object._type)
+                object_poses.append(obj.pose)
+            except:
+                pass
         return object_poses
 
     def select_object_for_grasping(self, object_poses):
@@ -89,9 +92,9 @@ class Pick(ScenarioStateBase):
             point_stamped.point.y = pose.pose.position.y
             point_stamped.point.z = pose.pose.position.z
             point_map_pos = self.tf_listener.transformPoint('map', point_stamped)
-            distances.append(robot_position, np.array([point_map_pos.point.x,
-                                                       point_map_pos.point.y,
-                                                       point_map_pos.point.z]))
+            distances.append(self.distance(robot_position, np.array([point_map_pos.point.x,
+                                                                     point_map_pos.point.y,
+                                                                     point_map_pos.point.z])))
 
         min_dist_obj_idx = np.argmin(distances)
         return min_dist_obj_idx

--- a/mdr_planning/mdr_scenarios/mdr_robocup_tasks/mdr_store_groceries/ros/src/mdr_store_groceries/scenario_states/pick.py
+++ b/mdr_planning/mdr_scenarios/mdr_robocup_tasks/mdr_store_groceries/ros/src/mdr_store_groceries/scenario_states/pick.py
@@ -72,9 +72,10 @@ class Pick(ScenarioStateBase):
         object_poses = list()
         for obj_name in surface_objects:
             try:
-                obj = self.msg_store_client.query_named(obj_name, Object._type)
+                obj = self.msg_store_client.query_named(obj_name, Object._type)[0]
                 object_poses.append(obj.pose)
             except:
+                rospy.logerr('Error retriving knowledge about %s', obj_name)
                 pass
         return object_poses
 

--- a/mdr_planning/mdr_scenarios/mdr_robocup_tasks/mdr_store_groceries/ros/src/mdr_store_groceries/scenario_states/place.py
+++ b/mdr_planning/mdr_scenarios/mdr_robocup_tasks/mdr_store_groceries/ros/src/mdr_store_groceries/scenario_states/place.py
@@ -46,8 +46,12 @@ class Place(ScenarioStateBase):
         return 'failed'
 
     def get_object_category(self, obj_name):
-        obj = self.msg_store_client.query_named(obj_name, Object._type)
-        return obj.category
+        try:
+            obj = self.msg_store_client.query_named(obj_name, Object._type)[0]
+            return obj.category
+        except:
+            rospy.logerr('Error retriving knowledge about %s', obj_name)
+            return ''
 
     def choose_placing_surface(self, obj_name, obj_category):
         obj_category_map = self.get_obj_category_map()


### PR DESCRIPTION
Fixed various problems with the pickup action; the manipulator is now sent to a pregrasp pose before grasping an object. In addition, grasping is done with respect to `base_link` rather than an arbitrary frame (even if the goal pose is given in another frame).

There was also an issue with the knowledge retrieval from `mongodb_store`. In particular, `query_named` returns a list rather than a single object, which I had not taken into account; this was causing exceptions in the pickup client, but also in the pick and place states of the store groceries state machine.

Finally, I've changed the `move_base` action so that it moves the manipulator to a safe configuration before navigation starts. There's currently no functionality for checking whether the arm is already in this safe configuration, so that remains to be added.

*Note*: I removed the `move_base` action from the `mdr_actions` namespace because moveit seems to fail if the group name is passed in a local scope.