### PR TITLE
[mdr_execution_manager] Added a state saving/SM recovery functionality

### DIFF
--- a/mdr_msgs/mdr_monitoring_msgs/CMakeLists.txt
+++ b/mdr_msgs/mdr_monitoring_msgs/CMakeLists.txt
@@ -3,24 +3,25 @@ project(mdr_monitoring_msgs)
 
 find_package(catkin REQUIRED
   COMPONENTS
-    roscpp
-    message_generation
-    std_msgs
+  roscpp
+  message_generation
+  std_msgs
 )
 
 add_message_files(
   FILES
-  AudioEndpoint.msg  
+  AudioEndpoint.msg
   Endpoints.msg
+  ExecutionState.msg
 )
 
 generate_messages(DEPENDENCIES std_msgs)
 
 catkin_package(
-	CATKIN_DEPENDS
-    message_runtime
-    rospy
-    std_msgs	
+  CATKIN_DEPENDS
+  message_runtime
+  rospy
+  std_msgs
 )
 
 include_directories(

--- a/mdr_msgs/mdr_monitoring_msgs/msg/ExecutionState.msg
+++ b/mdr_msgs/mdr_monitoring_msgs/msg/ExecutionState.msg
@@ -1,0 +1,3 @@
+time stamp
+string state_machine
+string state

--- a/mdr_planning/mdr_scenarios/mdr_execution_manager/README.md
+++ b/mdr_planning/mdr_scenarios/mdr_execution_manager/README.md
@@ -6,10 +6,12 @@ Creates and executes a smach state machine from a state machine description spec
 
 State machine configuration files can be specified in two different ways:
 
-* independently, i.e. a single configuration files fully describes a state machine
+* independently, i.e. a single configuration file fully describes a state machine
 * one state machine can inherit the structure from another state machine, but can also add new states and remove/replace states that exist in the parent state machine
 
 The latter allows defining generic/robot-independent state machines that can then be made specific by a robot-dependent definition. For example, the generic definition might contain an `arm_moving` state that might be defined somewhere in `mas_domestic_robotics`; however, this state might need to be reimplemented for a particular robot, such that the child configuration file allows us to specify the new state without redefining the complete state machine.
+
+State machines can also be resumed if states are saved as `mdr_monitoring_msgs/ExecutionState` messages using `mongodb_store`. Saving the state and resuming the execution can be enabled/disabled by passing the parameters `save_sm_state` and `recover_sm` when starting the creator node, which is launched by the `state_machine_creator` executable.
 
 ## Package organisation
 
@@ -31,6 +33,15 @@ mdr_execution_manager
           |____state_machine_creator
 
 ```
+
+## Dependencies
+
+* ``importlib``
+* ``rospy``
+* ``smach``
+* ``smach_ros``
+* ``mongodb_store``
+* ``mdr_monitoring_msgs``
 
 ## State machine configuration file syntax
 

--- a/mdr_planning/mdr_scenarios/mdr_execution_manager/ros/scripts/state_machine_creator
+++ b/mdr_planning/mdr_scenarios/mdr_execution_manager/ros/scripts/state_machine_creator
@@ -4,7 +4,9 @@ from importlib import import_module
 import rospy
 import smach
 import smach_ros
+from mongodb_store.message_store import MessageStoreProxy
 
+from mdr_monitoring_msgs.msg import ExecutionState
 from mdr_execution_manager.sm_loader import SMLoader
 
 class StateMachine(smach.StateMachine):
@@ -14,27 +16,86 @@ class StateMachine(smach.StateMachine):
     Email -- aleksandar.mitrevski@h-brs.de
 
     '''
-    def __init__(self, sm_data):
+    def __init__(self, sm_data, recover_sm=False, save_sm_state=False):
         smach.StateMachine.__init__(self, outcomes=sm_data.outcomes)
+        self.msg_store_client = MessageStoreProxy()
+
+        saved_state = None
+        if recover_sm:
+            saved_state = self.get_saved_state(sm_data.id)
+
         with self:
-            for _, state in sm_data.state_params.items():
+            if saved_state is not None:
+                rospy.loginfo('[SM creator] Starting state machine from state %s' % saved_state)
+                state = sm_data.state_params[saved_state]
                 state_class = getattr(import_module(state.state_module_name),
                                       state.state_class_name)
                 smach.StateMachine.add(state.name,
                                        state_class(**state.args),
                                        transitions=state.transitions)
 
+            for _, state in sm_data.state_params.items():
+                if state.name != saved_state:
+                    state_class = getattr(import_module(state.state_module_name),
+                                          state.state_class_name)
+                    smach.StateMachine.add(state.name,
+                                           state_class(save_sm_state=save_sm_state,
+                                                       **state.args),
+                                           transitions=state.transitions)
+
+    def get_saved_state(self, sm_id):
+        rospy.loginfo('[SM creator] Checking if the execution should continue from a saved state')
+        try:
+            state_msg = self.msg_store_client.query_named('current_state',
+                                                          ExecutionState._type)
+            execution_end_msg = self.msg_store_client.query_named('execution_end',
+                                                                  ExecutionState._type)
+
+            if state_msg and state_msg[0] is None:
+                return None
+
+            # we only consider saved states if the state machine did not
+            # finish fully the last time it was executed
+            if state_msg and state_msg[0].state_machine == sm_id:
+                if not execution_end_msg or \
+                execution_end_msg[0].stamp.secs < state_msg[0].stamp.secs:
+                    return state_msg[0].state
+            return None
+        except:
+            rospy.logerr('[SM creator] Error retriving knowledge about the current state')
+            return None
+
+    def save_execution_end(self, sm_id):
+        rospy.loginfo('[SM creator] Saving the end of the execution')
+        execution_state_msg = ExecutionState()
+        execution_state_msg.stamp = rospy.Time.now()
+        execution_state_msg.state_machine = sm_id
+        execution_state_msg.state = 'DONE'
+        try:
+            self.msg_store_client.insert_named('execution_end', execution_state_msg)
+        except:
+            rospy.logerr('[SM creator] Error while saving the execution end of %s' % sm_id)
+
+
 if __name__ == '__main__':
     sm_config_file = rospy.get_param('/sm_config_file', '')
     parent_sm_config_file = rospy.get_param('/parent_sm_config_file', '')
     sm_data = SMLoader.load_sm(sm_config_file, parent_sm_config_file)
 
+    recover_sm = rospy.get_param('/recover_sm', False)
+    save_sm_state = rospy.get_param('/save_sm_state', False)
+
     rospy.init_node(sm_data.id)
-    state_machine = StateMachine(sm_data)
+    state_machine = StateMachine(sm_data,
+                                 recover_sm=recover_sm,
+                                 save_sm_state=save_sm_state)
     smach_viewer = smach_ros.IntrospectionServer(sm_data.id, state_machine, sm_data.id)
     smach_viewer.start()
     result = state_machine.execute()
-    while result is None:
+    while result is None and not rospy.is_shutdown():
         rospy.spin()
     rospy.loginfo('%s complete' % (sm_data.id))
+
+    if save_sm_state:
+        state_machine.save_execution_end(sm_data.id)
     smach_viewer.stop()

--- a/mdr_planning/mdr_scenarios/mdr_execution_manager/ros/src/mdr_execution_manager/sm_loader.py
+++ b/mdr_planning/mdr_scenarios/mdr_execution_manager/ros/src/mdr_execution_manager/sm_loader.py
@@ -82,6 +82,10 @@ class SMLoader(object):
                         state_params.args[arg_data[SMFileKeys.ARG_NAME]] = \
                         arg_data[SMFileKeys.ARG_VALUE]
 
+                # we add the state machine ID and the state name as additional state arguments
+                state_params.args['sm_id'] = sm_params.id
+                state_params.args['state_name'] = state_params.name
+
                 sm_params.state_params[state_params.name] = state_params
         return sm_params
 


### PR DESCRIPTION
This pull request implements a state saving functionality in `mdr_execution_manager`. In particular, I've added an `mdr_monitoring_msgs/ExecutionState` message that can be saved using `mongodb_store`; this can be used for checking whether a state machine was completed or whether it should be continued from a certain state.

State saving and SM recovery can be enabled/disabled using two parameters -  `save_sm_state` and `recover_sm` - which can be passed when launching the SM creator node.