### PR TITLE
Event message

### DIFF
--- a/mdr_msgs/mdr_monitoring_msgs/CMakeLists.txt
+++ b/mdr_msgs/mdr_monitoring_msgs/CMakeLists.txt
@@ -13,6 +13,7 @@ add_message_files(
   AudioEndpoint.msg
   Endpoints.msg
   ExecutionState.msg
+  Event.msg
 )
 
 generate_messages(DEPENDENCIES std_msgs)

--- a/mdr_msgs/mdr_monitoring_msgs/msg/Event.msg
+++ b/mdr_msgs/mdr_monitoring_msgs/msg/Event.msg
@@ -1,0 +1,2 @@
+time stamp
+string description


### PR DESCRIPTION
Added an `Event` message to `mdr_monitoring_msgs` that can be used for data annotation (when an event of interest happens).

The message only includes a timestamp and a description. We might want to add labels to the message as well, but that can be done with a separate pull request.