### PR TITLE
Update path to renamed file

### DIFF
--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_object_action/CMakeLists.txt
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_object_action/CMakeLists.txt
@@ -48,7 +48,7 @@ include_directories(
 
 install(PROGRAMS
     ros/scripts/find_object_action
-    ros/scripts/find_object_client_test
+    ros/scripts/find_object_action_client_test
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}/scripts
 )
 


### PR DESCRIPTION
Just a small fix for a wrong path to a file that has been renamed in `mdr_find_object_action`.

This is required for Travis to build, see #122.