### PR TITLE
rename all ImageRecognition usages to RecognizeImage

### DIFF
--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_perceive_plane_action/README.md
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_perceive_plane_action/README.md
@@ -60,7 +60,7 @@ The following arguments may be passed when launching the action server:
 * ``detection_action_name``: name of the action server used for object detection.
   Action file: `mcr_perception_msgs/DetectScene.action`.
 * ``recognition_service_name``: the name of the image recognition service for classifying object.
-  Service file: `mcr_perception_msgs/ImageRecognition.srv`.
+  Service file: `mcr_perception_msgs/RecognizeImage.srv`.
 * ``recognition_model_name``: the name of the image classification model located in the `mdr_object_recognition`
   package.
 * ``preprocess_input_module``: the name of the module containing the image preprocessing function to be executed on

--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_perceive_plane_action/ros/src/mdr_perceive_plane_action/action_states.py
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_perceive_plane_action/ros/src/mdr_perceive_plane_action/action_states.py
@@ -4,7 +4,7 @@ import sensor_msgs.msg
 from pyftsm.ftsm import FTSMTransitions
 from mas_execution.action_sm_base import ActionSMBase
 from mcr_perception_msgs.msg import PlaneList
-from mas_perception_libs import ObjectDetector, ImageRecognitionServiceProxy
+from mas_perception_libs import ObjectDetector, RecognizeImageServiceProxy
 from mdr_perceive_plane_action.msg import PerceivePlaneResult, PerceivePlaneFeedback
 
 class PerceivePlaneSM(ActionSMBase):
@@ -17,9 +17,8 @@ class PerceivePlaneSM(ActionSMBase):
                  max_recovery_attempts=1):
         super(PerceivePlaneSM, self).__init__('PerceivePlane', [], max_recovery_attempts)
         self._detector = ObjectDetector(detection_service_proxy)
-        self._recog_service_proxy = ImageRecognitionServiceProxy(recog_service_name,
-                                                                 recog_model_name,
-                                                                 preprocess_input_module)
+        self._recog_service_proxy = RecognizeImageServiceProxy(recog_service_name, recog_model_name,
+                                                               preprocess_input_module)
         self._image_pub = rospy.Publisher('/first_recognized_image',
                                           sensor_msgs.msg.Image,
                                           queue_size=1)


### PR DESCRIPTION
In relation to b-it-bots/mas_perception#32, this will rename the image recognition service classes to match the other service names in `mas_perception`.