### PR TITLE
Fix reference to nonexistent package in mdr_listen_action

### DIFF
--- a/mdr_planning/mdr_actions/mdr_speech_actions/mdr_listen_action/CMakeLists.txt
+++ b/mdr_planning/mdr_actions/mdr_speech_actions/mdr_listen_action/CMakeLists.txt
@@ -8,6 +8,8 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   roslint
   rospy
+  mdr_speech_matching
+  mdr_speech_recognition
 )
 
 catkin_python_setup()
@@ -28,6 +30,8 @@ catkin_package(
    actionlib_msgs
    message_runtime
    std_msgs
+   mdr_speech_matching
+   mdr_speech_recognition
 )
 
 include_directories(

--- a/mdr_planning/mdr_actions/mdr_speech_actions/mdr_listen_action/package.xml
+++ b/mdr_planning/mdr_actions/mdr_speech_actions/mdr_listen_action/package.xml
@@ -15,12 +15,16 @@
   <build_depend>message_generation</build_depend>
   <build_depend>roslint</build_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>mdr_speech_matching</build_depend>
+  <build_depend>mdr_speech_recognition</build_depend>
 
   <run_depend>rospy</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>mdr_speech_matching</run_depend>
+  <run_depend>mdr_speech_recognition</run_depend>
 
   <export></export>
 </package>

--- a/mdr_planning/mdr_actions/mdr_speech_actions/mdr_listen_action/ros/scripts/listen_client_test
+++ b/mdr_planning/mdr_actions/mdr_speech_actions/mdr_listen_action/ros/scripts/listen_client_test
@@ -38,7 +38,7 @@ if __name__ == '__main__':
 
         timeout = 15.0
         client.wait_for_result(rospy.Duration.from_sec(int(timeout)))
-    rospy.loginfo(client.get_result())
+        rospy.loginfo(client.get_result())
 
     except Exception as ex:
         rospy.logerr(type(ex).__name__ + ": You have failed!")

--- a/mdr_planning/mdr_actions/mdr_speech_actions/mdr_listen_action/setup.py
+++ b/mdr_planning/mdr_actions/mdr_speech_actions/mdr_listen_action/setup.py
@@ -5,6 +5,6 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
    packages=['mdr_listen_action_ros'],
-   package_dir={'mdr_listen_action_ros': 'ros/src/mdr_listen_action_ros'})
+   package_dir={'': 'ros/src/'})
 
 setup(**d)

--- a/mdr_planning/mdr_actions/mdr_speech_actions/mdr_listen_action/setup.py
+++ b/mdr_planning/mdr_actions/mdr_speech_actions/mdr_listen_action/setup.py
@@ -4,8 +4,7 @@ from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
-   packages=['mdr_listen_action', 'mdr_listen_action_ros'],
-   package_dir={'mdr_listen_action': 'common/src/mdr_listen_action',
-                'mdr_listen_action_ros': 'ros/src/mdr_listen_action_ros'})
+   packages=['mdr_listen_action_ros'],
+   package_dir={'mdr_listen_action_ros': 'ros/src/mdr_listen_action_ros'})
 
 setup(**d)


### PR DESCRIPTION
This is a small fix that removes a reference in `setup.py` of `mdr_listen_action` to a python package that no longer exists.

This addresses #117 and #122. The Travis build for this PR should therefore complete successfully.