### PR TITLE
Find my mates bug fixes

### DIFF
--- a/mdr_planning/mdr_scenarios/mdr_robocup_tasks/mdr_find_my_mates/ros/src/mdr_find_my_mates/scenario_states/interview_person.py
+++ b/mdr_planning/mdr_scenarios/mdr_robocup_tasks/mdr_find_my_mates/ros/src/mdr_find_my_mates/scenario_states/interview_person.py
@@ -1,6 +1,7 @@
 import rospy
 import actionlib
 import rospkg
+from rasa_nlu.model import Interpreter
 
 from mas_perception_msgs.msg import Person
 from mdr_perception_msgs.msg import PersonInfo

--- a/mdr_planning/mdr_scenarios/mdr_robocup_tasks/mdr_find_my_mates/ros/src/mdr_find_my_mates/scenario_states/move_to_person.py
+++ b/mdr_planning/mdr_scenarios/mdr_robocup_tasks/mdr_find_my_mates/ros/src/mdr_find_my_mates/scenario_states/move_to_person.py
@@ -38,7 +38,7 @@ class MoveToPerson(ScenarioStateBase):
             return 'failed_after_retrying'
 
         person_to_interview = people_identifiers[0]
-        person_info = self.kb_interface.get_obj_instance(person_to_interview, Person)
+        person_info = self.kb_interface.get_obj_instance(person_to_interview, Person._type)
         person_pose = person_info.safe_pose
 
         move_base_goal = MoveBaseGoal()


### PR DESCRIPTION
This PR fixes two bugs in the `mdr_find_my_mates` scenario package:
* in the `move_to_person` state, fixed incorrect object retrieval from the knowledge base (this is the issue we were having during RoboCup)
* also added a missing import of `rasa_nlu.model.Interpreter` in the `interview_person` state