### PR TITLE
Move arm preemption and DMP refactoring

### DIFF
--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/CMakeLists.txt
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   smach_ros
   geometry_msgs
   moveit_commander
+  ros_dmp
 )
 
 roslint_python()
@@ -38,6 +39,7 @@ catkin_package(
    smach_ros
    geometry_msgs
    moveit_commander
+   ros_dmp
 )
 
 include_directories(

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/config/dmp.yaml
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/config/dmp.yaml
@@ -6,3 +6,4 @@ sigma_threshold_upper: 0.12
 sigma_threshold_lower: 0.07
 base_feedback_gain: 2.0
 use_whole_body_control: true
+linear_vel_limit: 0.05

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/config/dmp.yaml
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/config/dmp.yaml
@@ -1,0 +1,8 @@
+time_step: 0.001
+goal_tolerance_m: 0.05
+feedforward_gain: 30
+feedback_gain: 10
+sigma_threshold_upper: 0.12
+sigma_threshold_lower: 0.07
+base_feedback_gain: 2.0
+use_whole_body_control: true

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/package.xml
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/package.xml
@@ -21,6 +21,7 @@
   <build_depend>smach_ros</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>moveit_commander</build_depend>
+  <build_depend>ros_dmp</build_depend>
 
   <run_depend>rospy</run_depend>
   <run_depend>actionlib</run_depend>
@@ -30,6 +31,7 @@
   <run_depend>smach_ros</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>moveit_commander</run_depend>
+  <run_depend>ros_dmp</run_depend>
 
   <export></export>
 </package>

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/launch/move_arm.launch
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/launch/move_arm.launch
@@ -8,5 +8,6 @@
         <param name="arm_controller_sigma_values_topic" value="/arm_1/arm_controller/sigma_values" />
         <param name="path_topic" value="/dmp_executor/path" />
         <param name="move_base_server" value="move_base" />
+        <rosparam command="load" file="$(find mdr_move_arm_action)/config/dmp.yaml" />
     </node>
 </launch>

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/scripts/move_arm_action
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/scripts/move_arm_action
@@ -33,13 +33,11 @@ class MoveArmServer(object):
         self.action_sm.goal = goal
         self.action_sm.result = None
         self.action_sm.execution_requested = True
-        while not self.action_sm.result and not self.action_server.is_preempt_requested():
+        while not self.action_sm.result:
+            if self.action_server.is_preempt_requested():
+                self.action_sm.preempted = True
             rospy.sleep(0.05)
-
-        if not self.action_server.is_preempt_requested():
-            self.action_server.set_succeeded(self.action_sm.result)
-        else:
-            self.action_sm.preempted = True
+        self.action_server.set_succeeded(self.action_sm.result)
 
 if __name__ == '__main__':
     rospy.init_node('move_arm_server')

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/scripts/move_arm_action
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/scripts/move_arm_action
@@ -33,9 +33,13 @@ class MoveArmServer(object):
         self.action_sm.goal = goal
         self.action_sm.result = None
         self.action_sm.execution_requested = True
-        while not self.action_sm.result:
+        while not self.action_sm.result and not self.action_server.is_preempt_requested():
             rospy.sleep(0.05)
-        self.action_server.set_succeeded(self.action_sm.result)
+
+        if not self.action_server.is_preempt_requested():
+            self.action_server.set_succeeded(self.action_sm.result)
+        else:
+            self.action_sm.preempted = True
 
 if __name__ == '__main__':
     rospy.init_node('move_arm_server')

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/scripts/move_arm_action_client_preemption_test
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/scripts/move_arm_action_client_preemption_test
@@ -1,0 +1,43 @@
+#! /usr/bin/env python
+from __future__ import print_function
+from mas_tools.ros_utils import get_package_path
+
+import rospy
+import actionlib
+from geometry_msgs.msg import PoseStamped
+
+from mdr_move_arm_action.msg import MoveArmAction, MoveArmGoal
+
+if __name__ == '__main__':
+    rospy.init_node('move_arm_client_test')
+
+    client = actionlib.SimpleActionClient('/move_arm_server', MoveArmAction)
+    client.wait_for_server()
+
+    goal = MoveArmGoal()
+    goal.goal_type = MoveArmGoal.END_EFFECTOR_POSE
+    pose = PoseStamped()
+    pose.header.frame_id = 'base_link'
+
+    pose.pose.position.x = 0.45
+    pose.pose.position.y = 0.078
+    pose.pose.position.z = 0.8
+
+    pose.pose.orientation.x = 0.
+    pose.pose.orientation.y = 0.
+    pose.pose.orientation.z = 0.
+    pose.pose.orientation.w = 1.
+
+    goal.end_effector_pose = pose
+    goal.dmp_name = get_package_path('mdr_pickup_action', 'config',
+                                     'trajectory_weights', 'weights_table_grasp.yaml')
+    goal.dmp_tau = 30.
+
+    timeout = 5.
+    rospy.loginfo('Sending action lib goal to move_arm_server')
+    goal_handle = client.send_goal(goal)
+    rospy.sleep(timeout)
+
+    rospy.loginfo('Preempting action')
+    client.cancel_all_goals()
+    print(client.get_result())

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/action_states.py
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/action_states.py
@@ -51,7 +51,7 @@ class MoveArmSM(ActionSMBase):
                     rospy.sleep(0.05)
 
                 if self.preempted:
-                    dmp_traj_executor.motion_canceled = True
+                    dmp_traj_executor.motion_cancelled = True
                     self.preempted = False
 
                     rospy.loginfo('[move_arm] Cancelled arm motion')

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/action_states.py
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/action_states.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from threading import Thread
 import numpy as np
 
 import rospy
@@ -42,7 +43,20 @@ class MoveArmSM(ActionSMBase):
             if dmp_name:
                 dmp_traj_executor = DMPExecutor(dmp_name, tau)
                 goal = np.array([pose.pose.position.x, pose.pose.position.y, pose.pose.position.z])
-                dmp_traj_executor.execute(goal)
+
+                dmp_execution_thread = Thread(target=dmp_traj_executor.execute, args=(goal,))
+                dmp_execution_thread.start()
+                while not dmp_traj_executor.motion_completed and \
+                      not self.preempted:
+                    rospy.sleep(0.05)
+
+                if self.preempted:
+                    dmp_traj_executor.motion_canceled = True
+                    self.preempted = False
+
+                    rospy.loginfo('[move_arm] Cancelled arm motion')
+                    self.result = self.set_result(False)
+                    return FTSMTransitions.DONE
             else:
                 self.arm.set_pose_reference_frame(pose.header.frame_id)
                 self.arm.set_pose_target(pose.pose)

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/dmp.py
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/dmp.py
@@ -33,6 +33,7 @@ class DMPExecutor(object):
         self.sigma_threshold_upper = rospy.get_param('~sigma_threshold_upper', 0.12)
         self.sigma_threshold_lower = rospy.get_param('~sigma_threshold_upper', 0.07)
         self.use_whole_body_control = rospy.get_param('~use_whole_body_control', False)
+        self.linear_vel_limit = rospy.get_param('~linear_vel_limit', 0.05)
 
         rospy.Subscriber(self.arm_controller_sigma_values_topic,
                          Float32MultiArray, self.sigma_values_cb)
@@ -160,11 +161,11 @@ class DMPExecutor(object):
             vel_z = self.feedforward_gain * (path_z[ind] - path_z[index]) + self.feedback_gain * (path_z[ind] - current_pos[2])
 
             # limiting speed
-            norm_ = np.linalg.norm(np.array([vel_x, vel_y, vel_z]))
-            if norm_ > 0.05:
-                vel_x = vel_x * 0.05 / norm_
-                vel_y = vel_y * 0.05 / norm_
-                vel_z = vel_z * 0.05 / norm_
+            vel_norm = np.linalg.norm(np.array([vel_x, vel_y, vel_z]))
+            if vel_norm > self.linear_vel_limit:
+                vel_x = vel_x * self.linear_vel_limit / vel_norm
+                vel_y = vel_y * self.linear_vel_limit / vel_norm
+                vel_z = vel_z * self.linear_vel_limit / vel_norm
 
             vel_x_arm = vel_x
             vel_y_arm = vel_y

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/dmp.py
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/dmp.py
@@ -5,7 +5,6 @@ from geometry_msgs.msg import PoseStamped, TwistStamped, Vector3Stamped, Twist
 from nav_msgs.msg import Path
 import tf
 import actionlib
-from move_base_msgs.msg import MoveBaseAction, MoveBaseGoal
 from ros_dmp.roll_dmp import RollDmp
 
 
@@ -22,44 +21,34 @@ class DMPExecutor(object):
         self.arm_controller_sigma_values_topic = rospy.get_param('~arm_controller_sigma_values_topic',
                                                                  '/arm_controller/sigma_values')
         self.dmp_executor_path_topic = rospy.get_param('~path_topic', '/dmp_executor/path')
-        self.move_base_server = rospy.get_param('~move_base_server', 'move_base/move')
 
-        self.number_of_sampling_points = 30
-        self.goal_tolerance = 0.05
         self.vel_publisher_arm = rospy.Publisher(self.cartesian_velocity_topic,
                                                  TwistStamped, queue_size=1)
         self.vel_publisher_base = rospy.Publisher(self.base_vel_topic, Twist, queue_size=1)
-        self.feedforward_gain = 30
-        self.feedback_gain = 10
-        self.sigma_threshold_upper = 0.12
-        self.sigma_threshold_lower = 0.07
-        self.base_feedback_gain = 2.0
 
-        self.motion_completed = False
-        self.motion_cancelled = False
+        self.time_step = rospy.get_param('~time_step', 0.001)
+        self.goal_tolerance = rospy.get_param('~goal_tolerance_m', 0.05)
+        self.feedforward_gain = rospy.get_param('~feedforward_gain', 30)
+        self.feedback_gain = rospy.get_param('~feedback_gain', 10)
+        self.sigma_threshold_upper = rospy.get_param('~sigma_threshold_upper', 0.12)
+        self.sigma_threshold_lower = rospy.get_param('~sigma_threshold_upper', 0.07)
+        self.use_whole_body_control = rospy.get_param('~use_whole_body_control', False)
 
         rospy.Subscriber(self.arm_controller_sigma_values_topic,
                          Float32MultiArray, self.sigma_values_cb)
         self.path_pub = rospy.Publisher(self.dmp_executor_path_topic, Path, queue_size=1)
-        self.goal = None
+
         self.dmp_name = dmp_name
         self.tau = tau
-        self.roll_dmp = RollDmp(self.dmp_name, 0.001, self.base_link_frame_name)
+        self.roll_dmp = RollDmp(self.dmp_name, self.time_step, self.base_link_frame_name)
 
         self.min_sigma_value = None
-        self.deploy_wbc = True
-
-        # Move base server
-        self.move_base_client = actionlib.SimpleActionClient(self.move_base_server, MoveBaseAction)
-        self.move_base_client.wait_for_server()
+        self.goal = None
+        self.motion_completed = False
+        self.motion_cancelled = False
 
     def sigma_values_cb(self, msg):
         self.min_sigma_value = min(msg.data)
-
-    def move_base(self):
-        move_base_goal = MoveBaseGoal()
-        move_base_goal.target_pose.header.frame_id = self.map_frame_name
-        print(self.move_base_client.send_goal(move_base_goal))
 
     def generate_trajectory(self, goal, initial_pos):
         initial_pose = np.array([initial_pos[0], initial_pos[1], initial_pos[2], 0., 0., 0.])
@@ -186,7 +175,9 @@ class DMPExecutor(object):
             vel_z_base = 0.0
             ratio = 1.0
 
-            if self.min_sigma_value != None and self.min_sigma_value < self.sigma_threshold_upper and self.deploy_wbc:
+            if self.min_sigma_value != None and \
+               self.min_sigma_value < self.sigma_threshold_upper and \
+               self.use_whole_body_control:
                 ratio = (self.min_sigma_value - self.sigma_threshold_lower) / (self.sigma_threshold_upper - self.sigma_threshold_lower)
 
                 vel_x_arm = vel_x * (ratio)
@@ -236,7 +227,7 @@ class DMPExecutor(object):
         message_arm.twist.linear.z = 0
 
         self.vel_publisher_arm.publish(message_arm)
-        if self.deploy_wbc:
+        if self.use_whole_body_control:
             self.vel_publisher_base.publish(message_base)
 
     def execute(self, goal):


### PR DESCRIPTION
This PR implements goal cancelling for the move arm action, which is particularly useful for handling collisions.

In addition, the `dmp.py` script has been refactored, such that:
* the service call for generating a trajectory has been replaced by a roll DMP API call
* all configurable parameters are read from a YAML configuration file