### PR TITLE
[speech_recognition] point to kaldi models in mas_models

### DIFF
--- a/mdr_planning/mdr_actions/mdr_speech_actions/mdr_listen_action/ros/launch/listen.launch
+++ b/mdr_planning/mdr_actions/mdr_speech_actions/mdr_listen_action/ros/launch/listen.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
     <node pkg="mdr_listen_action" type="listen" name="listen_server" output="screen" >
-        <param name="model_directory" type="str" value="$(find mdr_speech_recognition)/config/models/tdnn_en" />
+        <param name="model_directory" type="str" value="$(find kaldi_speech_models)/common/config/en-US" />
         <param name="use_kaldi"       value="true"/>
     </node>
 </launch>

--- a/mdr_speech/mdr_speech_recognition/ros/launch/speech_recognition.launch
+++ b/mdr_speech/mdr_speech_recognition/ros/launch/speech_recognition.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
     <node pkg="mdr_speech_recognition" type="speech_recognition_node" name="speech_recognition_node" output="screen">
-        <param name="model_directory" type="str" value="$(find mdr_speech_recognition)/config/models/tdnn_en" />
+        <param name="model_directory" type="str" value="$(find kaldi_speech_models)/common/config/en-US" />
         <param name="use_kaldi"       value="true"/>
     </node>
 


### PR DESCRIPTION
The launch files for speech_recognition node and listen_action are now pointing at the correct Kaldi model. 