### PR TITLE
[handle_open_action] Handle detection

### DIFF
--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_handle_open_action/README.md
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_handle_open_action/README.md
@@ -6,8 +6,15 @@ An action for manipulating handles.
 
 ### Goal:
 
-* ``string handle_type``: Type of the handle (currently unused)
-* ``geometry_msgs/PoseStamped handle_pose``: Pose of the handle
+* ``string handle_type``: Optional type of the handle that needs to be opened
+
+The following constants are also defined in the action goal:
+* ``string PULL=pull_knob``
+* ``string LEVER=lever_knob``
+* ``string ROUND=round_knob``
+* ``string UNKNOWN=unknown``
+
+Note that these constants match the handle classes defined at https://github.com/b-it-bots/mas_models/blob/master/perception_models/detectors/classes_handles.yaml
 
 ### Result:
 
@@ -25,11 +32,24 @@ An action for manipulating handles.
 * ``move_arm_server``: Name of the move_arm action server (default: 'move_arm_server')
 * ``move_base_server``: Name of the move_base action server (default: 'move_base_server')
 * ``move_forward_server``: Name of the move_forward action server (default: 'move_forward_server')
+* ``detect_handle_server``: Name of a detect_handle action server (default: 'detect_handle_server')
 * ``force_sensor_topic``: Name of topic for wrist force sensor measurements (default: 'force_sensor_topic')
 * ``pregrasp_config_name``: Name of the pregrasp configuration (default: 'pregrasp_config_name')
 * ``final_config_name``: Name of the final configuration (default: 'final_config_name')
 * ``handle_open_dmp``: Path to a YAML file containing the weights of a dynamic motion primitive used for opening handles (default: '')
 * ``dmp_tau``: The value of the temporal dynamic motion primitive parameter (default: 30)
+
+## Action execution summary
+
+1. A handle is detected (including the type of handle and its pose)
+2. Depending on the handle type, a different opening policy is followed:
+    * a pull knob is the easiest to open since in that case the robot simply grasps the handle and moves backwards
+    * a round knob is similar to a pull knob, but the robot moves sideways as well
+    * for a lever knob, force feedback from the handle is used until the lever is pushed downwards and then the base moves to open the door
+
+In all three cases, the pose at which the handle is grasped is sampled from a learned distribution as described below.
+
+If `handle_type` is not `unknown`, the detected handle type is checked against the given type; if these don't match, an action failure is reported.
 
 ## Dependencies
 
@@ -41,6 +61,8 @@ An action for manipulating handles.
 * ``tf``
 * ``actionlib``
 * ``geometry_msgs``
+* ``mas_perception_msgs``
+* ``mas_perception_libs``
 * ``mas_execution``
 * ``mdr_rosplan_interface``
 * ``mdr_move_arm_action``
@@ -54,3 +76,7 @@ The package additionally includes some data (under `learning_data`) that was col
 There are two sets of poses there:
 * `sample_grasp_poses_uniform`: Poses sampled from a uniform distribution
 * `sample_grasp_poses_learned`: Poses sampled from the learned success distribution
+
+## Handle detection
+
+For the purpose of online handle detection, the action expects an action server of type `mas_perception_msgs/DetectObjectsAction` to be active. An example launch file for starting such a server is given at https://github.com/b-it-bots/mas_perception_libs/blob/devel/ros/launch/object_detection.launch. Note that a handle detection model can be found at https://github.com/b-it-bots/mas_models/tree/master/perception_models/detectors

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_handle_open_action/ros/action/HandleOpen.action
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_handle_open_action/ros/action/HandleOpen.action
@@ -1,6 +1,11 @@
-# goal
+string PULL=pull_knob
+string LEVER=lever_knob
+string ROUND=round_knob
+string UNKNOWN=unknown
+
+# optional handle type for cross-checking
+# the results of the online handle detection
 string handle_type
-geometry_msgs/PoseStamped handle_pose
 ---
 # result
 bool success

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_handle_open_action/ros/launch/handle_open_action.launch
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_handle_open_action/ros/launch/handle_open_action.launch
@@ -5,6 +5,7 @@
         <param name="move_arm_server" value="move_arm_server" />
         <param name="move_base_server" value="move_base_server" />
         <param name="move_forward_server" value="move_forward_server" />
+        <param name="detect_handle_server" value="detect_handle_server" />
         <param name="force_sensor_topic" value="/wrist_force/raw"/>
         <param name="pregrasp_config_name" value="pregrasp_low" />
         <param name="final_config_name" value="pregrasp" />

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_handle_open_action/ros/scripts/handle_open_action
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_handle_open_action/ros/scripts/handle_open_action
@@ -15,6 +15,7 @@ class HandleOpenServer(object):
     * move_arm_server: Name of the move_arm action server (default: 'move_arm_server')
     * move_base_server: Name of the move_base action server (default: 'move_base_server')
     * move_forward_server: Name of the move_forward action server (default: 'move_forward_server')
+    * detect_handle_server: Name of a detect_handle action server (default: 'detect_handle_server')
     * force_sensor_topic: Name of topic for wrist force sensor measurements
                           (default: 'force_sensor_topic')
     * pregrasp_config_name: Name of the pregrasp configuration (default: 'pregrasp_config_name')
@@ -30,6 +31,7 @@ class HandleOpenServer(object):
         move_arm_server = rospy.get_param('~move_arm_server', 'move_arm_server')
         move_base_server = rospy.get_param('~move_base_server', 'move_base_server')
         move_forward_server = rospy.get_param('~move_forward_server', 'move_forward_server')
+        detect_handle_server = rospy.get_param('~detect_handle_server', 'detect_handle_server')
         force_sensor_topic = rospy.get_param('~force_sensor_topic', 'force_sensor_topic')
         pregrasp_config_name = rospy.get_param('~pregrasp_config_name', 'pregrasp_config_name')
         final_config_name = rospy.get_param('~final_config_name', 'final_config_name')
@@ -42,6 +44,7 @@ class HandleOpenServer(object):
                                       move_base_server=move_base_server,
                                       force_sensor_topic=force_sensor_topic,
                                       move_forward_server=move_forward_server,
+                                      detect_handle_server=detect_handle_server,
                                       pregrasp_config_name=pregrasp_config_name,
                                       final_config_name=final_config_name,
                                       handle_open_dmp=handle_open_dmp,

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_handle_open_action/ros/scripts/handle_open_action_client_test
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_handle_open_action/ros/scripts/handle_open_action_client_test
@@ -16,57 +16,8 @@ if __name__ == '__main__':
     client = actionlib.SimpleActionClient('/handle_open_server', HandleOpenAction)
     client.wait_for_server()
 
-    random = False
-
     goal = HandleOpenGoal()
-
-    goal.handle_pose.header.frame_id = 'base_link'
-    goal.handle_pose.header.stamp = rospy.Time.now()
-
-    if random:
-        # Sampling Random Grasp Positions From a Uniform Distribution:
-
-        z_lim = [0.62, 0.72]
-        x_lim = [0.68, 0.71]
-        y_lim = [0.00, 0.20]
-
-        sample_grasp_pose = [np.random.uniform(low=x_lim[0], high=x_lim[1]),
-                             np.random.uniform(low=y_lim[0], high=y_lim[1]),
-                             np.random.uniform(low=z_lim[0], high=z_lim[1])]
-
-        # Saving the sampled position in a file:
-        # save_samples_to_file('sample_grasp_poses')
-
-    else:
-        # Sampling Grasp Positions From Learned Gaussian Distribution:
-
-        ## TODO: Sample and store positions, and use to continuously update parameters (lifelong learning)
-        # At the moment, use the values learned from the last experiment (13/09/19)
-        posterior_mu_estimate = [0.70064241, 0.10315619, 0.6579796]
-        posterior_sigma_estimate = [4.48271554e-05, 2.67117757e-03, 4.27263449e-04]
-
-        sample_grasp_pose = [np.random.multivariate_normal(np.array([posterior_mu_estimate[0]]),
-                                                           np.array([posterior_sigma_estimate[0]])[np.newaxis])[0],
-                             np.random.multivariate_normal(np.array([posterior_mu_estimate[1]]),
-                                                             np.array([posterior_sigma_estimate[1]])[np.newaxis])[0],
-                             np.random.multivariate_normal(np.array([posterior_mu_estimate[2]]),
-                                                             np.array([posterior_sigma_estimate[2]])[np.newaxis])[0]]
-
-        # Saving the positions sampled from the new distribution in a file:
-        # save_samples_to_file('new_sample_grasp_poses')
-
-    rospy.loginfo('Sampled Grasp Position: ')
-    print(sample_grasp_pose)
-    print()
-
-    goal.handle_pose.pose.position.x = sample_grasp_pose[0]
-    goal.handle_pose.pose.position.y = sample_grasp_pose[1]
-    goal.handle_pose.pose.position.z = sample_grasp_pose[2]
-
-    goal.handle_pose.pose.orientation.x = 0.000
-    goal.handle_pose.pose.orientation.y = 0.000
-    goal.handle_pose.pose.orientation.z = 0.000
-    goal.handle_pose.pose.orientation.w = 1.000
+    goal.handle_type = HandleOpenGoal.UNKNOWN
 
     timeout = 15.0
     rospy.loginfo('Sending action lib goal to handle_open_server')

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_handle_open_action/ros/src/mdr_handle_open_action/action_states.py
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_handle_open_action/ros/src/mdr_handle_open_action/action_states.py
@@ -105,7 +105,7 @@ class HandleOpenSM(ActionSMBase):
     def running(self):
         rospy.loginfo('[handle_open] Detecting handle')
         self.detect_handle_client.send_goal(DetectObjectsGoal())
-        self.detect_handle_client.wait_for_result(timeout=self.timeout)
+        self.detect_handle_client.wait_for_result(timeout=rospy.Duration.from_sec(self.timeout))
         detection_result = self.detect_handle_client.get_result()
 
         # if a handle could not be detected, the action is aborted

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_handle_open_action/ros/src/mdr_handle_open_action/action_states.py
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_handle_open_action/ros/src/mdr_handle_open_action/action_states.py
@@ -125,7 +125,7 @@ class HandleOpenSM(ActionSMBase):
                 return FTSMTransitions.DONE
 
         handle.pose.header.stamp = rospy.Time(0)
-        pose_base_link = self.tf_listener.transformPose('base_link', pose)
+        pose_base_link = self.tf_listener.transformPose('base_link', handle.pose)
 
         if self.base_elbow_offset > 0:
             self.__align_base_with_pose(pose_base_link)

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_handle_open_action/ros/src/mdr_handle_open_action/action_states.py
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_handle_open_action/ros/src/mdr_handle_open_action/action_states.py
@@ -115,7 +115,7 @@ class HandleOpenSM(ActionSMBase):
             return FTSMTransitions.DONE
 
         rospy.loginfo('[handle_open] Detected %d handles; taking closest handle',
-                      len(detected_handles.objects.objects))
+                      len(detection_result.objects.objects))
         handle = self.__get_closest_handle(detection_result.objects.objects)
         if self.goal.handle_type and self.goal.handle_type != HandleOpenGoal.UNKNOWN:
             if self.goal_handle_type != handle.category:


### PR DESCRIPTION
# Summary of changes

This PR modifies the `handle_open` action so that it includes handle detection (an object detection action as defined at https://github.com/b-it-bots/mas_perception_libs/blob/devel/ros/src/mas_perception_libs/scene_detection_action.py is used for that purpose). Since the handle detection is now part of the action, the pose is not passed as an action goal anymore; however, the handle type is still passed as an optional argument so that the results of the detection can be cross-checked with the expected handle type.

# Future TODOs

* Implement different opening policies depending on the handle type (with the current implementation, only pull handles can be opened)
* Integrate the grasp pose sampling into the action execution
* Add recovery behaviours (for example, if the detection fails in the current implementation, the action fails as well)

cc @njanirudh 