### PR TITLE
Head controller base

### DIFF
--- a/mdr_perception/mdr_head_controller/CMakeLists.txt
+++ b/mdr_perception/mdr_head_controller/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(mdr_head_controller)
+
+find_package(catkin REQUIRED
+  COMPONENTS
+    roslint
+    rospy
+)
+
+catkin_python_setup()
+roslint_python()
+
+catkin_package(
+  CATKIN_DEPENDS
+    std_msgs
+)
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(ros/launch)
+endif()
+
+install(PROGRAMS
+  ros/scripts/head_controller
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/mdr_perception/mdr_head_controller/README.md
+++ b/mdr_perception/mdr_head_controller/README.md
@@ -1,0 +1,40 @@
+# mdr_head_controller
+
+A package for functionalities related to controlling a robot's head.
+
+## Existing Functionalities
+
+### head_controller_base
+
+A base implementation of a high-level head controller for performing basic head motion commands, such as tilting the head up or down.
+
+The base class defines the following methods for controlling a head:
+* `look_up`: Moves the robot's head up. Returns a Boolean indicating whether the operation was successful.
+* `look_down`: Moves the robot's head down. Returns a Boolean indicating whether the operation was successful.
+* `turn_left`: Turns the robot's head to the left. Returns a Boolean indicating whether the operation was successful.
+* `turn_right`: Turns the robot's head to the right. Returns a Boolean indicating whether the operation was successful.
+
+Robot-specific implementations need to override all methods.
+
+A script that starts a `head_controller` node is also included in the package as an example, but a robot-specific implementation should start its own node.
+
+## Directory structure
+
+```
+mdr_head_controller
+|    CMakeLists.txt
+|    package.xml
+|    setup.py
+|    README.md
+|____ros
+     |____launch
+     |    |_____head_controller.launch
+     |    |
+     |    scripts
+     |    |_____head_controller
+     |    |
+     |____src
+          |____mdr_head_controller
+               |    __init__.py
+               |____head_controller_base.py
+```

--- a/mdr_perception/mdr_head_controller/package.xml
+++ b/mdr_perception/mdr_head_controller/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package>
+  <name>mdr_head_controller</name>
+  <version>1.0.0</version>
+  <description>Package for functionalities related to controlling a robot's head</description>
+
+  <license>GPLv3</license>
+
+  <author email="aleksandar.mitrevski@h-brs.de">Alex Mitrevski</author>
+  <maintainer email="robotics@inf.h-brs.de">MAS robotics</maintainer>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>rospy</build_depend>
+  <build_depend>roslint</build_depend>
+
+  <run_depend>std_msgs</run_depend>
+</package>

--- a/mdr_perception/mdr_head_controller/ros/launch/head_controller.launch
+++ b/mdr_perception/mdr_head_controller/ros/launch/head_controller.launch
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<launch>
+    <node pkg="mdr_head_controller" type="head_controller" name="mdr_head_controller" output="screen">
+    </node>
+</launch>

--- a/mdr_perception/mdr_head_controller/ros/scripts/head_controller
+++ b/mdr_perception/mdr_head_controller/ros/scripts/head_controller
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+import rospy
+
+from mdr_head_controller.head_controller_base import HeadControllerBase
+
+if __name__ == '__main__':
+    rospy.init_node('mdr_head_controller')
+    try:
+        HeadControllerBase()
+    except rospy.ROSInterruptException:
+        pass

--- a/mdr_perception/mdr_head_controller/ros/src/mdr_head_controller/head_controller_base.py
+++ b/mdr_perception/mdr_head_controller/ros/src/mdr_head_controller/head_controller_base.py
@@ -1,0 +1,12 @@
+class HeadControllerBase(object):
+    def look_up(self):
+        raise NotImplementedError('look_up not implemented')
+
+    def look_down(self):
+        raise NotImplementedError('look_down not implemented')
+
+    def turn_left(self):
+        raise NotImplementedError('turn_left not implemented')
+
+    def turn_right(self):
+        raise NotImplementedError('turn_right not implemented')

--- a/mdr_perception/mdr_head_controller/setup.py
+++ b/mdr_perception/mdr_head_controller/setup.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+d = generate_distutils_setup(
+    packages=['mdr_head_controller'],
+    package_dir={'mdr_head_controller': 'ros/src/mdr_head_controller'}
+)
+
+setup(**d)


### PR DESCRIPTION
This PR adds a package `mdr_head_controller` in the `mdr_perception` metapackage. `mdr_head_controller` is designed just as the `mdr_gripper_controller` package, namely it defines a base head controller whose methods are meant to be overriden in robot-specific implementations.

The base controller defines four functions for controlling a robot's head: `look_up`, `look_down`, `turn_left`, and `turn_right`. These will primarily be useful for implementing recovery behaviours (e.g. when the perception fails, the head could be moved slightly so that the robot gets a different viewpoint of the scene before it attempts perceiving again), but can also be useful for HRI-specific task (e.g. for turning towards a speaker).