### PR TITLE
Head controller instance in the perceive plane action

### DIFF
--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_perceive_plane_action/README.md
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_perceive_plane_action/README.md
@@ -61,6 +61,9 @@ The following arguments may be passed when launching the action server:
   package.
 * ``preprocess_input_module``: the name of the module containing the image preprocessing function to be executed on
   images before inference.
+* ``head_controller_pkg_name``: name of a package that implements functionalities
+  for controlling a robot's head (default: 'mdr_head_controller')
+
 
 ### Action client
 

--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_perceive_plane_action/ros/launch/perceive_plane.launch
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_perceive_plane_action/ros/launch/perceive_plane.launch
@@ -7,6 +7,7 @@
     <arg name="recognition_model_name" default="athome_xception"/>
     <arg name="preprocess_input_module" default="keras.applications.xception"/>
     <arg name="classify_object" default="false"/>
+    <arg name="head_controller_pkg_name" default="mdr_head_controller"/>
 
     <node pkg="mdr_perceive_plane_action" type="perceive_plane_action" name="perceive_plane_server" output="screen"
           ns="mdr_actions">
@@ -16,6 +17,7 @@
         <param name="recognition_model_name" type="string" value="$(arg recognition_model_name)" />
         <param name="preprocess_input_module" type="string" value="$(arg preprocess_input_module)" />
         <param name="classify_object" type="bool" value="$(arg classify_object)" />
+        <param name="head_controller_pkg_name" type="string" value="$(arg head_controller_pkg_name)" />
     </node>
 
     <include file="$(find mdr_object_recognition)/ros/launch/object_recognition.launch">

--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_perceive_plane_action/ros/scripts/perceive_plane_action
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_perceive_plane_action/ros/scripts/perceive_plane_action
@@ -16,6 +16,8 @@ class PerceivePlaneServer(object):
                                to be executed on images before inference
     * target_frame: Name of the reference frame the object and plane poses will be
                     transformed to (default: '/base_link')
+    * head_controller_pkg_name: Name of a package that implements functionalities for
+                                controlling a robot's head (default: 'mdr_head_controller')
 
     @author Minh Nguyen, Alex Mitrevski
     @contact minh.nguyen@smail.inf.h-brs.de, aleksandar.mitrevski@h-brs.de
@@ -25,11 +27,14 @@ class PerceivePlaneServer(object):
         detection_action_name = rospy.get_param('~detection_action_name', '/base_link')
         if not detection_action_name:
             raise RuntimeError('[perceive_plane] no detection action server specified')
-        recognition_service_name = rospy.get_param('~recognition_service_name', '/mdr_perception/recognize_image')
+        recognition_service_name = rospy.get_param('~recognition_service_name',
+                                                   '/mdr_perception/recognize_image')
         recognition_model_name = rospy.get_param('~recognition_model_name', 'athome_xception_v1')
         preprocess_input_module = rospy.get_param('~preprocess_input_module', None)
         classify_object = rospy.get_param('~classify_object', True)
         target_frame = rospy.get_param('~target_frame', '')
+        head_controller_pkg_name = rospy.get_param('~head_controller_pkg_name',
+                                                   'mdr_head_controller')
 
         rospy.loginfo('[perceive_plane] Initialising state machine')
         self.action_sm = PerceivePlaneSM(detection_service_proxy=detection_action_name,
@@ -37,7 +42,8 @@ class PerceivePlaneServer(object):
                                          recog_model_name=recognition_model_name,
                                          preprocess_input_module=preprocess_input_module,
                                          target_frame=target_frame,
-                                         classify_object=classify_object)
+                                         classify_object=classify_object,
+                                         head_controller_pkg_name=head_controller_pkg_name)
         rospy.loginfo('[perceive_plane] State machine initialised')
 
         self.action_server = actionlib.SimpleActionServer('perceive_plane_server',

--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_perceive_plane_action/ros/src/mdr_perceive_plane_action/action_states.py
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_perceive_plane_action/ros/src/mdr_perceive_plane_action/action_states.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python
+from importlib import import_module
+
 import rospy
 from pyftsm.ftsm import FTSMTransitions
 from mas_execution.action_sm_base import ActionSMBase
@@ -11,6 +13,7 @@ class PerceivePlaneSM(ActionSMBase):
                  recog_service_name,
                  recog_model_name,
                  preprocess_input_module,
+                 head_controller_pkg_name='mdr_head_controller',
                  classify_object=True,
                  target_frame=None,
                  timeout_duration=1,
@@ -23,6 +26,11 @@ class PerceivePlaneSM(ActionSMBase):
         self._timeout_duration = timeout_duration
         self._target_frame = target_frame
         self._detecting_done = False
+
+        head_controller_module_name = '{0}.head_controller'.format(head_controller_pkg_name)
+        HeadControllerClass = getattr(import_module(head_controller_module_name),
+                                      'HeadController')
+        self._head = HeadControllerClass()
 
     def running(self):
         detected_planes = None


### PR DESCRIPTION
Related to https://github.com/b-it-bots/mas_domestic_robotics/pull/209

The PR adds an additional argument to the `perceive_plane` action, which specifies the name of a head controller package; this is then used internally by the action for creating a head controller instance. The way this is handled is equivalent to how this is done with the gripper controller in the manipulation actions, e.g. `pickup`.

The ultimate purpose is to use the head controller for recovery, but that should be done with a separate PR.