### PR TITLE
Context in the pickup action goal

### DIFF
--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/README.md
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/README.md
@@ -10,10 +10,16 @@ The action includes an action server as well as an action client that interacts 
 
 * ``geometry_msgs/PoseStamped pose``: An end-effector goal pose
 * ``uint32 strategy``: Grasping strategy
+* ``string context``: Grasping context
 
 The following constants are also defined in the action goal:
-* ``uint32 SIDEWAYS_GRASP=0``
-* ``uint32 TOP_GRASP=1``
+* grasping strategies:
+    * ``uint32 SIDEWAYS_GRASP=0``
+    * ``uint32 TOP_GRASP=1``
+* grasping contexts:
+    * ``string CONTEXT_MOVING=pick_to_move``
+    * ``string CONTEXT_STORING=pick_to_store``
+    * ``string CONTEXT_TABLETOP_MANIPULATION=pick_for_tabletop_manipulation``
 
 ### Result:
 

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/ros/action/Pickup.action
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/ros/action/Pickup.action
@@ -2,8 +2,13 @@
 uint32 SIDEWAYS_GRASP=0
 uint32 TOP_GRASP=1
 
+string CONTEXT_MOVING=pick_to_move
+string CONTEXT_STORING=pick_to_store
+string CONTEXT_TABLETOP_MANIPULATION=pick_for_tabletop_manipulation
+
 geometry_msgs/PoseStamped pose
 uint32 strategy
+string context
 ---
 # result
 bool success

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/ros/src/mdr_pickup_action/action_states.py
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/ros/src/mdr_pickup_action/action_states.py
@@ -151,13 +151,14 @@ class PickupSM(ActionSMBase):
             rospy.loginfo('[pickup] Closing the gripper')
             self.gripper.close()
 
-            rospy.loginfo('[pickup] Moving the arm back')
-            self.__move_arm(MoveArmGoal.NAMED_TARGET, self.safe_arm_joint_config)
+            if self.goal.context != PickupGoal.CONTEXT_TABLETOP_MANIPULATION:
+                rospy.loginfo('[pickup] Moving the arm back')
+                self.__move_arm(MoveArmGoal.NAMED_TARGET, self.safe_arm_joint_config)
 
-            if self.goal.strategy == PickupGoal.TOP_GRASP:
-                rospy.loginfo('[pickup] Moving the base back to the original position')
-                if abs(x_align_distance) > 0:
-                    self.__move_base_along_x(-x_align_distance)
+                if self.goal.strategy == PickupGoal.TOP_GRASP:
+                    rospy.loginfo('[pickup] Moving the base back to the original position')
+                    if abs(x_align_distance) > 0:
+                        self.__move_base_along_x(-x_align_distance)
 
             rospy.loginfo('[pickup] Verifying the grasp...')
             grasp_successful = self.gripper.verify_grasp()


### PR DESCRIPTION
This PR adds a `context` variable to the goal of the `pickup` action and defines three context constants:
* `string CONTEXT_MOVING=pick_to_move`
* `string CONTEXT_STORING=pick_to_store`
* `string CONTEXT_TABLETOP_MANIPULATION=pick_for_tabletop_manipulation`

In the case of picking for tabletop manipulation, the arm doesn't go back to a safe position so that other actions (e.g. pulling or pushing) can be used afterwards.

Other contexts can be added in future if necessary.

The README of the action has been updated to reflect the changes.