### PR TITLE
Online DMP Trajectory Generation

### DIFF
--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/dmp.py
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/dmp.py
@@ -56,7 +56,7 @@ class DMPExecutor(object):
         as encoded by self.dmp_name.
 
         Keyword arguments:
-        goal: np.array -- end effector goal position in the base link frame
+        goal: numpy.ndarray -- end effector goal position in the base link frame
 
         '''
         initial_pos = None
@@ -81,8 +81,8 @@ class DMPExecutor(object):
         on the path.
 
         Keyword arguments:
-        initial_pos: np.array -- initial position for the motion
-        goal: np.array -- goal position
+        initial_pos: numpy.ndarray -- initial position for the motion
+        goal: numpy.ndarray -- goal position
 
         '''
         initial_pose = np.array([initial_pos[0], initial_pos[1], initial_pos[2], 0., 0., 0.])
@@ -132,7 +132,7 @@ class DMPExecutor(object):
           minimum sigma value (determined experimentally)
 
         Keyword arguments:
-        path: np.array -- a 2D array of points (each row represents a point)
+        path: numpy.ndarray -- a 2D array of points (each row represents a point)
 
         '''
         rospy.loginfo('[move_arm/dmp/follow_path] Executing motion')
@@ -276,7 +276,7 @@ class DMPExecutor(object):
         '''Publishes the given path to the topic specified by self.dmp_executor_path_topic.
 
         Keyword arguments:
-        path: np.array -- a 2D array of points in which each row represents a position
+        path: numpy.ndarray -- a 2D array of points in which each row represents a position
 
         '''
         path_msg = Path()

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/dmp.py
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/dmp.py
@@ -301,9 +301,12 @@ class DMPExecutor(object):
         self.min_sigma_value = min(msg.data)
 
     def instantiate_dmp(self, initial_pose, goal_pose):
-        ''' ...
-        ...
-        ...
+        '''Instantiates a DMP object from learned weights, given 
+        the initial and final poses.
+
+        Keyword arguments:
+        initial_pose: numpy.ndarray -- initial pose coordinates of end-effector
+        goal_pose: numpy.ndarray -- target pose coordinates of end-effector
         '''
         with open(self.dmp_name) as f:
             dmp_weights_dict = yaml.load(f)


### PR DESCRIPTION
# Summary of changes

This PR addresses the first item in #230.
It introduces a change in the way in which a trajectory is stepped though in the DMPExecutor. Instead of rolling out the whole trajectory, storing the end-effector coordinates, and then sending velocity commands in the control loop, individual trajectory steps are generated within the control loop. 


# Tests To Verify Changes

- The modified DMP executor was tested on the robot by running the `pickup action` and verifying that the generated trajectory matches the one produced by the original, offline trajectory generation strategy.