### PR TITLE
DMP execution bug fix

### DIFF
--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/action_states.py
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/action_states.py
@@ -33,7 +33,7 @@ class MoveArmSM(ActionSMBase):
             rospy.loginfo('[move_arm] Planning motion and trying to move arm...')
             success = self.arm.go(wait=True)
         elif self.goal.goal_type == MoveArmGoal.END_EFFECTOR_POSE:
-            pose = self.goal.end_effector_pose
+            goal = self.goal.end_effector_pose
             dmp_name = self.goal.dmp_name
             tau = self.goal.dmp_tau
             rospy.loginfo('[move_arm] Planning motion and trying to move arm...')
@@ -42,8 +42,6 @@ class MoveArmSM(ActionSMBase):
             # otherwise, we just use moveit for planning a trajectory and moving the arm
             if dmp_name:
                 dmp_traj_executor = DMPExecutor(dmp_name, tau)
-                goal = np.array([pose.pose.position.x, pose.pose.position.y, pose.pose.position.z])
-
                 dmp_execution_thread = Thread(target=dmp_traj_executor.move_to, args=(goal,))
                 dmp_execution_thread.start()
                 while not dmp_traj_executor.motion_completed and \
@@ -58,8 +56,8 @@ class MoveArmSM(ActionSMBase):
                     self.result = self.set_result(False)
                     return FTSMTransitions.DONE
             else:
-                self.arm.set_pose_reference_frame(pose.header.frame_id)
-                self.arm.set_pose_target(pose.pose)
+                self.arm.set_pose_reference_frame(goal.header.frame_id)
+                self.arm.set_pose_target(goal.pose)
                 success = self.arm.go(wait=True)
         elif self.goal.goal_type == MoveArmGoal.JOINT_VALUES:
             joint_values = self.goal.joint_values

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/dmp.py
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/dmp.py
@@ -74,33 +74,6 @@ class DMPExecutor(object):
 
         self.follow_path(initial_pos, goal)
 
-    def generate_trajectory(self, initial_pos, goal):
-        '''Returns a 2D numpy array representing a path of [x, y, z] points
-        from "initial_pos" to "goal" that follows the trajectory encoded
-        by self.dmp_name. Each row in the resulting array is a single point
-        on the path.
-
-        Keyword arguments:
-        initial_pos: numpy.ndarray -- initial position for the motion
-        goal: numpy.ndarray -- goal position
-
-        '''
-        initial_pose = np.array([initial_pos[0], initial_pos[1], initial_pos[2], 0., 0., 0.])
-        goal_pose = np.array([goal[0], goal[1], goal[2], 0., 0., 0.])
-
-        print('[move_arm/dmp] Querying trajectory')
-        print('[move_arm/dmp] Initial pose: ', initial_pose)
-        print('[move_arm/dmp] Goal pose: ', goal_pose)
-        cartesian_trajectory, _ = self.roll_dmp.get_trajectory_and_path(goal_pose,
-                                                                        initial_pose,
-                                                                        self.tau)
-
-        path = np.array([[state.pose.position.x,
-                          state.pose.position.y,
-                          state.pose.position.z]
-                         for state in cartesian_trajectory.cartesian_state])
-        return path
-
     def follow_path(self, initial_pos,  goal):
         '''Moves a manipulator so that it follows the given path. If whole body
         motion is enabled and some points on the path lie outside the reachable
@@ -301,7 +274,7 @@ class DMPExecutor(object):
         self.min_sigma_value = min(msg.data)
 
     def instantiate_dmp(self, initial_pose, goal_pose):
-        '''Instantiates a DMP object from learned weights, given 
+        '''Instantiates a DMP object from learned weights, given
         the initial and final poses.
 
         Keyword arguments:
@@ -321,10 +294,10 @@ class DMPExecutor(object):
         dmp_weights[4, :] = dmp_weights_dict['pitch']
         dmp_weights[5, :] = dmp_weights_dict['yaw']
 
-        return pydmps.dmp_discrete.DMPs_discrete(n_dmps=n_dmps, 
+        return pydmps.dmp_discrete.DMPs_discrete(n_dmps=n_dmps,
                                                  n_bfs=n_bfs,
                                                  dt=self.time_step,
                                                  y0=initial_pose,
                                                  goal=goal_pose,
-                                                 ay=None, 
+                                                 ay=None,
                                                  w=dmp_weights)

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/dmp.py
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/dmp.py
@@ -50,31 +50,21 @@ class DMPExecutor(object):
         self.motion_completed = False
         self.motion_cancelled = False
 
-    def move_to(self, goal):
+    def move_to(self, goal_pose):
         '''Moves the end effector to the given goal position (which is expected
         to be given with respect to the base link frame) by following a trajectory
         as encoded by self.dmp_name.
 
         Keyword arguments:
-        goal: numpy.ndarray -- end effector goal position in the base link frame
+        goal_pose: geometry_msgs.msg.PoseStamped -- end effector goal pose
 
         '''
-        initial_pos = None
-        try:
-            self.tf_listener.waitForTransform(self.base_link_frame_name,
-                                              self.palm_link_name,
-                                              rospy.Time.now(),
-                                              rospy.Duration(30))
-            (trans, _) = self.tf_listener.lookupTransform(self.base_link_frame_name,
-                                                          self.palm_link_name,
-                                                          rospy.Time(0))
-            initial_pos = np.array(trans)
-        except (tf.LookupException, tf.ConnectivityException, tf.ExtrapolationException):
-            initial_pos = np.zeros(3)
+        (trans, _) = self.get_transform(self.odom_frame_name, self.palm_link_name, rospy.Time.now())
+        initial_pos_odom = np.array(trans)
+        goal_odom = self.transform_pose(goal_pose, self.odom_frame_name)
+        self.follow_path(initial_pos_odom, goal_odom)
 
-        self.follow_path(initial_pos, goal)
-
-    def follow_path(self, initial_pos,  goal):
+    def follow_path(self, initial_pos_odom,  goal_pose_odom):
         '''Moves a manipulator so that it follows the given path. If whole body
         motion is enabled and some points on the path lie outside the reachable
         workspace, the base is moved accordingly as well. The path is followed
@@ -105,15 +95,25 @@ class DMPExecutor(object):
           minimum sigma value (determined experimentally)
 
         Keyword arguments:
-        path: numpy.ndarray -- a 2D array of points (each row represents a point)
+        initial_pos_odom: numpy.ndarray -- the initial position of the end effector
+                                           in the odometry frame
+        goal_pose_odom: geometry_msgs.msg.PoseStamped -- end effector goal pose
+                                                         in the odometry frame
 
         '''
         rospy.loginfo('[move_arm/dmp/follow_path] Executing motion')
         trans, _ = self.get_transform(self.odom_frame_name, self.palm_link_name, rospy.Time(0))
         current_pos = np.array([trans[0], trans[1], trans[2]])
+        goal = np.array([goal_pose_odom.pose.position.x,
+                         goal_pose_odom.pose.position.y,
+                         goal_pose_odom.pose.position.z])
+
         distance_to_goal = np.linalg.norm((goal - current_pos))
 
-        initial_pose = np.array([initial_pos[0], initial_pos[1], initial_pos[2], 0., 0., 0.])
+        initial_pose = np.array([initial_pos_odom[0],
+                                 initial_pos_odom[1],
+                                 initial_pos_odom[2],
+                                 0., 0., 0.])
         goal_pose = np.array([goal[0], goal[1], goal[2], 0., 0., 0.])
 
         current_path = initial_pose[:3]
@@ -220,30 +220,22 @@ class DMPExecutor(object):
                 continue
         return (trans, rot)
 
-    def transform_pose(self, position, source_frame, target_frame):
-        '''Transforms a given (x, y, z) position (assuming a (0, 0, 0) rotation)
-        from the source frame to the target frame. Returns a numpy array with the
-        (x, y, z) position represented in the target frame.
+    def transform_pose(self, pose_msg, target_frame):
+        '''Transforms the given pose to the target frame.
 
         Keyword arguments:
-        position: np.array -- (x, y, z) position to be transformed
-        source_frame: str -- name of the transformation source frame
+        pose_msg: geometry_msgs.msg.PoseStamped -- pose to be transformed
         target_frame: str -- name of the transformation target frame
 
         '''
-        pose_msg = PoseStamped()
-        pose_msg.header.frame_id = source_frame
-        pose_msg.pose.position.x = position[0]
-        pose_msg.pose.position.y = position[1]
-        pose_msg.pose.position.z = position[2]
-
+        transformed_pose = pose_msg
         while not rospy.is_shutdown():
             try:
-                pose_ = self.tf_listener.transformPose(target_frame, pose_msg)
+                transformed_pose = self.tf_listener.transformPose(target_frame, pose_msg)
                 break
             except:
                 continue
-        return np.array([pose_.pose.position.x, pose_.pose.position.y, pose_.pose.position.z])
+        return transformed_pose
 
     def publish_path(self, path):
         '''Publishes the given path to the topic specified by self.dmp_executor_path_topic.


### PR DESCRIPTION
### Short description

The PR resolves a small bug in the DMP execution. The problem was that the initial position and the goal were both taken with respect to the base link frame, but during the execution, the current pose of the end effector was taken with respect to the odometry frame. As a result, the arm motion would drift over time.

To resolve this, both the initial pose and the goal pose are now transformed to the odometry frame before execution starts, thereby ensuring that all poses are in the same frame.

### Tests to verify the changes

The changes have been verified on our HSR and seem to resolve the issue.