### PR TITLE
[find_people] Detector replacement (SSD Keras -> PyTorch Faster R-CNN)

### DIFF
--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/package.xml
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/package.xml
@@ -27,4 +27,10 @@
   <run_depend>mas_perception_msgs</run_depend>
   <run_depend>mas_perception_libs</run_depend>
 
+  <run_depend>numpy</run_depend>
+  <run_depend>torch</run_depend>
+  <run_depend>scikit-learn</run_depend>
+  <run_depend>face_recognition</run_depend>
+  <run_depend>python-pcl</run_depend>
+
 </package>

--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/ros/launch/find_people.launch
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/ros/launch/find_people.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
     <arg name="pointcloud_topic" default="/mdr_perception/rectified_points"/>
-    <arg name="class_annotation_file" default="$(find mas_perception_libs)/models/coco_classes.yaml"/>
+    <arg name="class_annotation_file" default="$(find mas_perception_libs)/models/coco_classes.yml"/>
     <arg name="detector_module" default="torchvision.models.detection"/>
     <arg name="detector_name" default="fasterrcnn_resnet50_fpn"/>
     <arg name="detection_threshold" default="0.8"/>

--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/ros/launch/find_people.launch
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/ros/launch/find_people.launch
@@ -1,10 +1,18 @@
 <?xml version="1.0"?>
 <launch>
     <arg name="pointcloud_topic" default="/mdr_perception/rectified_points"/>
+    <arg name="class_annotation_file" default="$(find mas_perception_libs)/models/coco_classes.yaml"/>
+    <arg name="detector_module" default="torchvision.models.detection"/>
+    <arg name="detector_name" default="fasterrcnn_resnet50_fpn"/>
+    <arg name="detection_threshold" default="0.8"/>
     <arg name="face_embedding_model_path" default="/home/robot/models/face_embedding_model.pt"/>
 
     <node pkg="mdr_find_people" type="find_people_server" name="find_people_server" output="screen" >
         <param name="pointcloud_topic" type="string" value="$(arg pointcloud_topic)" />
+        <param name="class_annotation_file" type="string" value="$(arg class_annotation_file)" />
+        <param name="detector_module" type="string" value="$(arg detector_module)" />
+        <param name="detector_name" type="string" value="$(arg detector_name)" />
+        <param name="detection_threshold" type="string" value="$(arg detection_threshold)" />
         <param name="face_embedding_model_path" type="string" value="$(arg face_embedding_model_path)" />
     </node>
 </launch>

--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/ros/scripts/find_people_client_test
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/ros/scripts/find_people_client_test
@@ -3,11 +3,14 @@
 import rospy
 import actionlib
 
+from sensor_msgs.msg import Image
+
 from mdr_find_people.msg import FindPeopleAction, FindPeopleGoal
 
 
 if __name__ == '__main__':
     rospy.init_node('find_people_client_test')
+    person_img_pub = rospy.Publisher('/find_people_client_test/person', Image, queue_size=1)
 
     rospy.loginfo('Waiting for server...')
     client = actionlib.SimpleActionClient('find_people_server', FindPeopleAction)
@@ -16,9 +19,9 @@ if __name__ == '__main__':
     goal = FindPeopleGoal()
 
     try:
-        print('Sending goal...')
+        rospy.loginfo('Sending goal...')
         client.send_goal(goal)
-        print('Waiting for result...')
+        rospy.loginfo('Waiting for result...')
         client.wait_for_result(rospy.Duration.from_sec(120))
 
         result = client.get_result()
@@ -26,7 +29,12 @@ if __name__ == '__main__':
             rospy.logerr('No people found')
         rospy.loginfo('Found {0} people'.format(len(result.person_list.persons)))
         for person in result.person_list.persons:
-            rospy.loginfo('Image_size: width -- {0}, height -- {1}'.format(person.rgb_image.width, person.rgb_image.height))
+            rospy.loginfo('Image_size: width -- {0}, height -- {1}'.format(person.views[0].image.width,
+                                                                           person.views[0].image.height))
+
+            rospy.loginfo('Publishing image and sleeping for 3s')
+            person_img_pub.publish(person.views[0].image)
+            rospy.sleep(3.)
+        rospy.loginfo('Client test done')
     except Exception as e:
         rospy.logerr('Failed to execute find people action: {}'.format(repr(e)))
-

--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/ros/src/mdr_find_people/action_states.py
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/ros/src/mdr_find_people/action_states.py
@@ -1,8 +1,11 @@
+from importlib import import_module
+from PIL import Image as PILImage
+import yaml
+
 import rospy
 import smach
 import torch
 
-from PIL import Image as PILImage
 import tf
 from sensor_msgs.msg import PointCloud2, Image
 from mdr_find_people.msg import FindPeopleResult
@@ -25,16 +28,44 @@ class FindPeopleState(smach.State):
 
         self._listener = tf.TransformListener()
         self.pointcloud_topic = rospy.get_param("~pointcloud_topic", '/rectified_points')
+        self.class_annotation_file = rospy.get_param('class_annotation_file', '')
+        self.detector_module = rospy.get_param('detector_module', 'torchvision.models.detection')
+        self.detector_name = rospy.get_param('detector_name', 'fasterrcnn_resnet50_fpn')
+        self.detection_threshold = float(rospy.get_param('detection_threshold', 0.))
         self.face_embedding_model_path = rospy.get_param("~face_embedding_model_path", '')
+
+        if not self.class_annotation_file:
+            raise ValueError('Parameter "class_annotation_file" cannot be empty!')
+
+        self.class_annotations = None
+        with open(self.class_annotation_file, 'r') as annotations_file:
+            self.class_annotations = yaml.safe_load(annotations_file)
+        self.class_annotations[0] = 'background'
+
+        if not self.detector_module:
+            rospy.logwarn('[find_people] Found empty "detector_module"; using default torchvision.models.detection')
+            self.detector_module = 'torchvision.models.detection'
+
+        if not self.detector_name:
+            rospy.logwarn('[find_people] Found empty "detector_name"; using default fasterrcnn_resnet50_fpn')
+            self.detector_module = 'fasterrcnn_resnet50_fpn'
+
+        self.model_device = torch.device('cuda') if torch.cuda.is_available() \
+                                                 else torch.device('cpu')
+        detector_class = getattr(import_module(self.detector_module),
+                                 self.detector_name)
+        self.detector = detector_class(pretrained=True)
+        self.detector.eval()
+        self.detector.to(self.model_device)
 
         self.face_embedding_model = None
         if self.face_embedding_model_path:
             self.face_embedding_model = SiameseNetwork()
             self.face_embedding_model.load_state_dict(torch.load(self.face_embedding_model_path))
             self.face_embedding_model.eval()
+            self.face_embedding_model.to(self.model_device)
 
-            device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
-            self.face_embedding_model.to(device)
+        self.cv_bridge = CvBridge()
 
     def execute(self, userdata):
         rospy.loginfo('Executing state FIND_PEOPLE')
@@ -43,22 +74,25 @@ class FindPeopleState(smach.State):
         cloud_msg = rospy.wait_for_message(self.pointcloud_topic, PointCloud2)
 
         # Get positions of people
-        predictions, bb2ds, poses = FindPeople.detect(cloud_msg)
+        predictions, bb2ds, poses = FindPeople.detect(cloud_msg,
+                                                      self.detector,
+                                                      self.model_device,
+                                                      self.class_annotations,
+                                                      self.detection_threshold)
 
         # Get people images
         cv_image = cloud_msg_to_cv_image(cloud_msg)
-        bridge = CvBridge()
         images = []
         face_images = []
         for i, bb2d in enumerate(bb2ds):
             cropped_cv = crop_image(cv_image, bb2d)
-            cropped_img_msg = bridge.cv2_to_imgmsg(cropped_cv, encoding="passthrough")
+            cropped_img_msg = self.cv_bridge.cv2_to_imgmsg(cropped_cv, encoding="passthrough")
 
             rospy.loginfo('[find_people] Attempting to extract face of person {0}'.format(i+1))
             cropped_face_img = FindPeople.extract_face_image(cropped_cv)
             if cropped_face_img is not None:
-                cropped_face_img_msg = bridge.cv2_to_imgmsg(cropped_face_img,
-                                                            encoding='passthrough')
+                cropped_face_img_msg = self.cv_bridge.cv2_to_imgmsg(cropped_face_img,
+                                                                    encoding='passthrough')
             else:
                 cropped_face_img_msg = Image()
 
@@ -83,7 +117,7 @@ class FindPeopleState(smach.State):
             face_view.image = face_images[i]
 
             if self.face_embedding_model is not None and face_view.image.data:
-                face_cv2 = bridge.imgmsg_to_cv2(face_view.image)
+                face_cv2 = self.cv_bridge.imgmsg_to_cv2(face_view.image)
                 img_tensor = get_transforms()(PILImage.fromarray(face_cv2))
                 img_tensor.unsqueeze_(0)
 

--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/ros/src/mdr_find_people/action_states.py
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/ros/src/mdr_find_people/action_states.py
@@ -28,10 +28,10 @@ class FindPeopleState(smach.State):
 
         self._listener = tf.TransformListener()
         self.pointcloud_topic = rospy.get_param("~pointcloud_topic", '/rectified_points')
-        self.class_annotation_file = rospy.get_param('class_annotation_file', '')
-        self.detector_module = rospy.get_param('detector_module', 'torchvision.models.detection')
-        self.detector_name = rospy.get_param('detector_name', 'fasterrcnn_resnet50_fpn')
-        self.detection_threshold = float(rospy.get_param('detection_threshold', 0.))
+        self.class_annotation_file = rospy.get_param('~class_annotation_file', '')
+        self.detector_module = rospy.get_param('~detector_module', 'torchvision.models.detection')
+        self.detector_name = rospy.get_param('~detector_name', 'fasterrcnn_resnet50_fpn')
+        self.detection_threshold = float(rospy.get_param('~detection_threshold', 0.))
         self.face_embedding_model_path = rospy.get_param("~face_embedding_model_path", '')
 
         if not self.class_annotation_file:

--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/ros/src/mdr_find_people/find_people.py
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/ros/src/mdr_find_people/find_people.py
@@ -24,16 +24,27 @@ class FindPeople(object):
         img = cloud_msg_to_cv_image(cloud_msg)
         transform = T.ToTensor()
         img, _ = transform(img, None)
+
+        rospy.loginfo('Running detector...')
         with torch.no_grad():
             predictions = detector([img.to(detector_device)])
 
         # Get bounding boxes
+        rospy.loginfo('Processing detections...')
         detections = TorchImageDetector.process_predictions(predictions=predictions[0],
                                                             classes=class_annotations,
                                                             detection_threshold=detection_threshold)
+
+        rospy.loginfo('Extracting bounding boxes...')
         bounding_boxes = ImageDetectorBase.prediction_to_bounding_boxes(detections)[0]
+
+        rospy.loginfo('Extracting people detections...')
         people_detections, bb2ds = FindPeople.filter_people(detections, bounding_boxes)
+
+        rospy.loginfo('Extracting person poses...')
         poses = FindPeople.get_people_poses(cloud_msg, people_detections, bounding_boxes)
+        rospy.loginfo('Person detection complete')
+
         return people_detections, bb2ds, poses
 
     @staticmethod

--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/ros/src/mdr_find_people/find_people.py
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/ros/src/mdr_find_people/find_people.py
@@ -28,7 +28,7 @@ class FindPeople(object):
             predictions = detector([img.to(detector_device)])
 
         # Get bounding boxes
-        detections = TorchImageDetector.process_predictions(predictions=predictions,
+        detections = TorchImageDetector.process_predictions(predictions=predictions[0],
                                                             classes=class_annotations,
                                                             detection_threshold=detection_threshold)
         bounding_boxes = ImageDetectorBase.prediction_to_bounding_boxes(detections)[0]

--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/ros/src/mdr_find_people/find_people.py
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/ros/src/mdr_find_people/find_people.py
@@ -39,13 +39,22 @@ class FindPeople(object):
         bounding_boxes = ImageDetectorBase.prediction_to_bounding_boxes(detections)[0]
 
         rospy.loginfo('Extracting people detections...')
-        people_detections, bb2ds = FindPeople.filter_people(detections, bounding_boxes)
+        person_detections, person_bb2ds = FindPeople.filter_people(detections,
+                                                                   bounding_boxes)
 
-        rospy.loginfo('Extracting person poses...')
-        poses = FindPeople.get_people_poses(cloud_msg, people_detections, bounding_boxes)
+        if len(person_detections) == 1:
+            rospy.loginfo('Found one person')
+        else:
+            rospy.loginfo('Found {0} people'.format(len(person_detections)))
+
+        person_poses = []
+        if person_detections:
+            rospy.loginfo('Extracting person poses...')
+            person_poses = FindPeople.get_people_poses(cloud_msg,
+                                                       person_detections,
+                                                       person_bb2ds)
         rospy.loginfo('Person detection complete')
-
-        return people_detections, bb2ds, poses
+        return (person_detections, person_bb2ds, person_poses)
 
     @staticmethod
     def filter_people(predictions, bounding_boxes):


### PR DESCRIPTION
### Summary of changes

This PR replaces the *SSD Keras* model used in the `find_people` action with the PyTorch-based [*Faster R-CNN ResNet-50 FPN* model](https://pytorch.org/docs/stable/torchvision/models.html). This is part of an effort to replace all Tensorflow-based models in our code base with PyTorch-based models (which already started with https://github.com/b-it-bots/mas_domestic_robotics/pull/207).

### Related PRs:
* https://github.com/b-it-bots/mas_perception_libs/pull/21
* https://github.com/b-it-bots/mas_perception_libs/pull/22

### Tests to verify the changes

I performed tests with Lucy for verifying the changes.

cc @AhmedFaisal95 