### PR TITLE
[perceive_plane_action] Plane detector using a Torch-based object detector

### DIFF
--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_perceive_plane_action/config/object_detection_kwargs.yml
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_perceive_plane_action/config/object_detection_kwargs.yml
@@ -1,0 +1,3 @@
+detector_module: torchvision.models.detection
+detector_instantiator: fasterrcnn_resnet50_fpn
+detection_threshold: 0.8

--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_perceive_plane_action/ros/launch/perceive_plane.launch
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_perceive_plane_action/ros/launch/perceive_plane.launch
@@ -9,6 +9,12 @@
     <arg name="classify_object" default="false"/>
     <arg name="head_controller_pkg_name" default="mdr_head_controller"/>
 
+    <arg name="cloud_topic" default="" />
+    <arg name="object_detection_module" default="mas_perception_libs" />
+    <arg name="object_detection_class" default="TorchImageDetector" />
+    <arg name="object_detection_class_annotations" default="$(find mas_perception_libs)/models/coco_classes.yml" />
+    <arg name="object_detection_kwargs_file" default="$(find mdr_perceive_plane_action)/config/object_detection_kwargs.yml" />
+
     <node pkg="mdr_perceive_plane_action" type="perceive_plane_action" name="perceive_plane_server" output="screen"
           ns="mdr_actions">
         <param name="target_frame" type="string" value="$(arg target_frame)" />
@@ -19,6 +25,16 @@
         <param name="classify_object" type="bool" value="$(arg classify_object)" />
         <param name="head_controller_pkg_name" type="string" value="$(arg head_controller_pkg_name)" />
     </node>
+
+    <include file="$(find mas_perception_libs)/ros/launch/plane_detection.launch" >
+        <arg name="cloud_topic" value="$(arg cloud_topic)" />
+        <arg name="target_frame" value="$(arg target_frame)" />
+        <arg name="action_name" value="$(arg detection_action_name)" />
+        <arg name="detection_module" value="$(arg object_detection_module)" />
+        <arg name="detection_class" value="$(arg object_detection_class)" />
+        <arg name="class_annotations" value="$(arg object_detection_class_annotations)" />
+        <arg name="kwargs_file" value="$(arg object_detection_kwargs_file)" />
+    </include>
 
     <include file="$(find mdr_object_recognition)/ros/launch/object_recognition.launch">
         <arg name="service_name" value="$(arg recognition_service_name)"/>

--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_perceive_plane_action/ros/src/mdr_perceive_plane_action/action_states.py
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_perceive_plane_action/ros/src/mdr_perceive_plane_action/action_states.py
@@ -21,9 +21,12 @@ class PerceivePlaneSM(ActionSMBase):
                  max_recovery_attempts=1):
         super(PerceivePlaneSM, self).__init__('PerceivePlane', [], max_recovery_attempts)
         self._detector = PlaneDetector(detection_service_proxy)
-        self._recog_service_proxy = RecognizeImageServiceProxy(recog_service_name, recog_model_name,
-                                                               preprocess_input_module)
         self._classify_object = classify_object
+        self._recog_service_proxy = None
+        if self._classify_object:
+            self._recog_service_proxy = RecognizeImageServiceProxy(recog_service_name,
+                                                                   recog_model_name,
+                                                                   preprocess_input_module)
         self._timeout_duration = timeout_duration
         self._target_frame = target_frame
         self._detecting_done = False


### PR DESCRIPTION
### Summary of changes

This PR modifies the launch file of the `perceive_plane` action, which now loads a plane detector that uses a PyTorch-based detector (as in https://github.com/b-it-bots/mas_domestic_robotics/pull/245, [*Faster R-CNN ResNet-50 FPN* model](https://pytorch.org/docs/stable/torchvision/models.html) is used). This thus means that the repository does not depend on `ssd_keras_ros` anymore.

A config file for the detector is included under `mdr_perceive_plane_action/config`.

The PR also prevents the action from creating a recognition proxy unless this feature is enabled through the appropriate launch file parameter; otherwise, the proxy was created without being used internally.

### Tests to verify the changes

The working of the modified component has been verified with a bag file that was recently collected from the HSR (here, the robot observes small objects on the floor).