### PR TITLE
Fix Codacy errors and add configuration files to skip some pylint and bandit tests

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,5 @@
 [bandit]
-skips: B403,B301,B311
+skips:
+    B403, # `import_pickle` (Consider possible security implications associated with these modules.)
+    B301, # `pickle` (Pickle and modules that wrap it can be unsafe when used to deserialize untrusted data, possible security issue.)
+    B311  # `random` (Standard pseudo-random generators are not suitable for security/cryptographic purposes.)

--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,2 @@
+[bandit]
+skips: B403,B301,B311

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,3 @@
+disable=
+    no-self-use,
+    bare-except

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_place_action/ros/src/mdr_place_action/action_states.py
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_place_action/ros/src/mdr_place_action/action_states.py
@@ -10,7 +10,7 @@ from pyftsm.ftsm import FTSMTransitions
 from mas_execution.action_sm_base import ActionSMBase
 from mdr_move_base_action.msg import MoveBaseAction, MoveBaseGoal
 from mdr_move_arm_action.msg import MoveArmAction, MoveArmGoal
-from mdr_place_action.msg import PlaceFeedback, PlaceResult
+from mdr_place_action.msg import PlaceResult
 
 class PlaceSM(ActionSMBase):
     def __init__(self, timeout=120.0,

--- a/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/ros/src/mdr_find_people/find_people.py
+++ b/mdr_planning/mdr_actions/mdr_perception_actions/mdr_find_people/ros/src/mdr_find_people/find_people.py
@@ -11,8 +11,7 @@ from std_msgs.msg import Header
 from geometry_msgs.msg import Pose, PoseStamped, Point, Quaternion
 
 from mas_perception_libs import ImageDetectionKey, ImageDetectorBase, TorchImageDetector
-from mas_perception_libs.utils import cloud_msg_to_image_msg, cloud_msg_to_cv_image, \
-                                      crop_cloud_to_xyz
+from mas_perception_libs.utils import cloud_msg_to_cv_image, crop_cloud_to_xyz
 from mas_perception_libs.visualization import draw_labeled_boxes
 
 import dataset_interface.object_detection.transforms as T


### PR DESCRIPTION
This PR removes unused imports in python scripts and disables the following tests in `pylint` and `bandit` tools used by Codacy

*Pylint:*
    * `no-self-use`
    * `bare-except` 

*[Bandit](https://github.com/PyCQA/bandit):*
    * `B403`: import_pickle
    * `B301`: pickle
    * `B311`:  random

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
