### PR TITLE
Enable CI only for devel, kinetic & melodic branches, PRs and Tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,12 @@ before_install:
 
 
 stages:
-  - build
-  - test
+  - name: build
+    if: branch IN (devel, kinetic, melodic) OR type == "pull_request" OR tag = true
+  - name: test
+    if: branch IN (devel, kinetic, melodic) OR type == "pull_request" OR tag = true
   - name: deploy
-    if: (branch IN (devel, indigo, kinetic, melodic) AND type != "pull_request") OR tag = true
+    if: (branch IN (devel, kinetic, melodic) AND type != "pull_request") OR tag = true
 
 
 jobs:


### PR DESCRIPTION
This PR disables CI build for feature branches. The CI will only be triggered for `devel`, `melodic`, `kinetic` branches. Additionally, the CI will also be triggered for pull requests and git tags.

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

* Removed indigo branch for travis deploy stage
* Add conditions for triggering the travis `build` and `test` stages

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
