### PR TITLE
update rosinstall files to noetic branches

### DIFF
--- a/mas-domestic-devel.rosinstall
+++ b/mas-domestic-devel.rosinstall
@@ -1,7 +1,7 @@
 - git:
     local-name: mas_common_robotics
     uri: https://github.com/b-it-bots/mas_common_robotics.git
-    version: kinetic
+    version: noetic
 
 - git:
     local-name: mas_domestic_robotics
@@ -21,7 +21,7 @@
 - git:
     local-name: mas_perception_msgs
     uri: https://github.com/b-it-bots/mas_perception_msgs.git
-    version: kinetic-devel
+    version: noetic-devel
 
 - git:
     local-name: mas_execution_manager
@@ -65,12 +65,12 @@
 - git:
     local-name: mongodb_store
     uri: https://github.com/b-it-bots/mongodb_store.git
-    version: kinetic-devel
+    version: noetic-devel
 
 - git:
     local-name: occupancy_grid_utils
     uri: https://github.com/b-it-bots/occupancy_grid_utils.git
-    version: indigo-devel
+    version: noetic-devel
 
 - git:
     local-name: orocos_kinematics_dynamics
@@ -80,7 +80,7 @@
 - git:
     local-name: kdl_parser
     uri: https://github.com/ros/kdl_parser.git
-    version: kinetic-devel
+    version: noetic-devel
 
 - git:
     local-name: demonstrated_trajectory_recorder

--- a/mas-domestic.rosinstall
+++ b/mas-domestic.rosinstall
@@ -1,12 +1,12 @@
 - git:
     local-name: mas_common_robotics
     uri: https://github.com/b-it-bots/mas_common_robotics.git
-    version: kinetic
+    version: noetic
 
 - git:
     local-name: mas_domestic_robotics
     uri: https://github.com/b-it-bots/mas_domestic_robotics.git
-    version: kinetic
+    version: noetic
 
 - git:
     local-name: mas_navigation_tools
@@ -16,7 +16,7 @@
 - git:
     local-name: mas_perception_libs
     uri: https://github.com/b-it-bots/mas_perception_libs.git
-    version: kinetic
+    version: noetic
 
 - git:
     local-name: mas_perception_msgs
@@ -65,7 +65,7 @@
 - git:
     local-name: mongodb_store
     uri: https://github.com/b-it-bots/mongodb_store.git
-    version: kinetic-devel
+    version: noetic-devel
 
 - git:
     local-name: occupancy_grid_utils
@@ -80,7 +80,7 @@
 - git:
     local-name: kdl_parser
     uri: https://github.com/ros/kdl_parser.git
-    version: kinetic-devel
+    version: noetic-devel
 
 - git:
     local-name: ros_dmp

--- a/mas-domestic.rosinstall
+++ b/mas-domestic.rosinstall
@@ -21,7 +21,7 @@
 - git:
     local-name: mas_perception_msgs
     uri: https://github.com/b-it-bots/mas_perception_msgs.git
-    version: kinetic
+    version: noetic
 
 - git:
     local-name: mas_execution_manager


### PR DESCRIPTION
The current `rosinstall` files are very outdated. This PR updates them to pull from noetic branches. Maybe pending on b-it-bots/mas_perception_msgs#20 to be resolved.