### PR TITLE
fix DMP action result and use DMP in test script

### DIFF
--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/scripts/move_arm_action_client_test
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/scripts/move_arm_action_client_test
@@ -8,6 +8,7 @@ import roslib
 import actionlib
 from geometry_msgs.msg import PoseStamped
 
+from mas_tools.ros_utils import get_package_path
 from mdr_move_arm_action.msg import MoveArmAction, MoveArmGoal
 
 def print_usage_info():
@@ -54,7 +55,9 @@ if __name__ == '__main__':
                 pose.pose.orientation.w = params[7]
 
                 goal.end_effector_pose = pose
-                goal.dmp_name = ''
+                goal.dmp_name = get_package_path('mdr_pickup_action', 'config',
+                                                 'trajectory_weights', 'weights_table_grasp.yaml')
+                goal.dmp_tau = 30.
             elif goal.goal_type == MoveArmGoal.JOINT_VALUES:
                 params = ast.literal_eval(sys.argv[2])
                 goal.joint_values = params

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/action_states.py
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/action_states.py
@@ -105,6 +105,8 @@ class MoveArmSM(ActionSMBase):
                     rospy.loginfo('[move_arm] Cancelled arm motion')
                     self.result = self.set_result(False)
                     return FTSMTransitions.DONE
+
+                success = True
             else:
                 if self.whole_body:
                     rospy.loginfo('[move_arm] Planning whole body motion...')

--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/package.xml
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_pickup_action/package.xml
@@ -47,6 +47,7 @@
   <run_depend>mdr_rosplan_interface</run_depend>
   <run_depend>mdr_move_arm_action</run_depend>
   <run_depend>mdr_move_base_action</run_depend>
+  <run_depend>mdr_move_forward_action</run_depend>
 
   <export></export>
 </package>


### PR DESCRIPTION
- set success to True at end of DMP execution path in move_arm server (before the action would always return false)
- change move_arm test script to use DMP for end-effector pose
- add dependency to move_forwad in pickup action