### PR TITLE
fix default launch files and package dependencies

### DIFF
--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/package.xml
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/package.xml
@@ -33,6 +33,8 @@
   <run_depend>moveit_commander</run_depend>
   <run_depend>ros_dmp</run_depend>
   <run_depend>mdr_manipulation_msgs</run_depend>
+  <run_depend>mas_execution_manager</run_depend>
+  <run_depend>mas_tools</run_depend>
 
   <export></export>
 </package>

--- a/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/launch/move_base_action.launch
+++ b/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/launch/move_base_action.launch
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <launch>
+    <arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)" />
     <arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)" />
     <arg name="move_arm_server" default="move_arm_server" />
     <arg name="move_base_server" default="/move_base" />
@@ -17,6 +18,6 @@
         <param name="timeout" value="$(arg timeout)" />
         <param name="recovery_position_m_std" value="$(arg recovery_position_m_std)" />
         <param name="max_recovery_attempts" value="$(arg max_recovery_attempts)" />
-        <param name="pose_description_file" value="$(find mdr_environments)/$(arg robot_env)/navigation_goals.yaml" />
+        <param name="pose_description_file" value="$(find mas_environments)/$(arg robot)/$(arg robot_env)/navigation_goals.yaml" />
     </node>
 </launch>


### PR DESCRIPTION
- adapt arguments of launch file for move base action to use `mas_environments` instead of `mdr_environments`, which require `ROBOT` environment variable to be set
- add runtime dependencies for `mdr_move_arm_action`