### PR TITLE
[move_arm] set negative c to 0

### DIFF
--- a/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/dmp.py
+++ b/mdr_planning/mdr_actions/mdr_manipulation_actions/mdr_move_arm_action/ros/src/mdr_move_arm_action/dmp.py
@@ -180,6 +180,9 @@ class DMPExecutor(object):
                 # so-called capability coefficient, which is calculated as
                 #     (\sigma_{min} - \sigma_{low}) / (\sigma{high} - \sigma_{low})
                 c = (self.min_sigma_value - self.sigma_threshold_lower) / (self.sigma_threshold_upper - self.sigma_threshold_lower)
+                if c < 0:
+                    # negative c should be set to 0 to avoid unexpected behaviour
+                    c = 0
                 vel_arm[0:2] = vel[0:2] * c
                 vel_base[0:2] = vel[0:2] * (1 - c)
 


### PR DESCRIPTION
In effect, when the smallest eigenvalue of the arm Jacobian matrix is smaller than the lower sigma threshold, the base velocity is multiplied with a factor of 1., while arm velocity is set to 0. This is to prevent the unexpected behaviour of the base velocity being multiplied to a number greater than 1.