### PR TITLE
Handle invalid pose name

### DIFF
--- a/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/src/mdr_move_base_action/action_states.py
+++ b/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/src/mdr_move_base_action/action_states.py
@@ -103,6 +103,11 @@ class MoveBaseSM(ActionSMBase):
             rospy.loginfo('[move_base] Moving base to %s', destination)
 
             self.pose = self.convert_pose_name_to_coordinates(destination)
+            if self.pose is None:
+                rospy.logerr(f"[move_base] unknown named goal: {destination}")
+                self.result = self.set_result(False)
+                return FTSMTransitions.DONE
+
             pose.header.stamp = rospy.Time.now()
             pose.header.frame_id = self.pose_frame
             pose.pose.position.x = self.pose[0]

--- a/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/src/mdr_move_base_action/action_states.py
+++ b/mdr_planning/mdr_actions/mdr_navigation_actions/mdr_move_base_action/ros/src/mdr_move_base_action/action_states.py
@@ -175,7 +175,6 @@ class MoveBaseSM(ActionSMBase):
 
     def convert_pose_name_to_coordinates(self, pose_name):
         if pose_name not in self._named_poses:
-            rospy.logerr(f"[move_base] unrecognized pose name: '{pose_name}'")
             return None
         return self._named_poses[pose_name]
 


### PR DESCRIPTION
Log error and set result to False when an unrecognized named goal is received. This avoids `NoneType` exception being thrown later on when pose object is written to.
